### PR TITLE
archive: add merge/export subcommands

### DIFF
--- a/pkg/commands/archive.go
+++ b/pkg/commands/archive.go
@@ -36,6 +36,8 @@ hangar archive ls -f SAVED_ARCHIVE.zip`,
 
 	addCommands(cc.cmd,
 		newArchiveLsCmd(),
+		newArchiveMergeCmd(),
+		newArchiveExportCmd(),
 	)
 	return cc
 }

--- a/pkg/commands/archiveExport.go
+++ b/pkg/commands/archiveExport.go
@@ -1,0 +1,176 @@
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cnrancher/hangar/pkg/cmdconfig"
+	"github.com/cnrancher/hangar/pkg/hangar/archive"
+	"github.com/cnrancher/hangar/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type archiveExportOpts struct {
+	file           string
+	source         string
+	sourceRegistry string
+	destination    string
+	failed         string
+	autoYes        bool
+}
+
+type archiveExportCmd struct {
+	*baseCmd
+	*archiveExportOpts
+}
+
+func newArchiveExportCmd() *archiveExportCmd {
+	cc := &archiveExportCmd{
+		archiveExportOpts: &archiveExportOpts{},
+	}
+
+	cc.baseCmd = newBaseCmd(&cobra.Command{
+		Use:   "export",
+		Short: "Export images from hangar archive file into a new archive file",
+		Long:  "Export some images from hangar archive file into a new archive file by image list file.",
+		Example: `
+# Export images from archive file
+hangar archive export \
+	--file IMAGE_LIST.txt \
+	--source SAVED_ARCHIVE.zip \
+	--destination EXPORT_OUTPUT.zip`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			initializeFlagsConfig(cmd, cmdconfig.DefaultProvider)
+			if cc.baseCmd.debug {
+				logrus.SetLevel(logrus.DebugLevel)
+				logrus.Debugf("debug output enabled")
+				logrus.Debugf("%v", utils.PrintObject(cmdconfig.Get("")))
+			}
+
+			if err := cc.run(); err != nil {
+				return err
+			}
+			return nil
+		},
+	})
+
+	flags := cc.baseCmd.cmd.Flags()
+	flags.StringVarP(&cc.file, "file", "f", "", "image list file (required)")
+	flags.StringVarP(&cc.source, "source", "s", "", "source archive file")
+	flags.StringVarP(&cc.sourceRegistry, "source-registry", "", "", "override the source registry of image list file")
+	flags.StringVarP(&cc.destination, "destination", "d", "", "destination archive file")
+	flags.StringVarP(&cc.failed, "failed", "", "export-failed.txt", "export failed image list file name")
+	flags.BoolVarP(&cc.autoYes, "auto-yes", "y", false, "answer yes automatically (used in shell script)")
+
+	return cc
+}
+
+func (cc *archiveExportCmd) run() error {
+	if cc.file == "" {
+		return fmt.Errorf("image list file not provided, use '--file' to specify the image list file")
+	}
+	if cc.source == "" {
+		return fmt.Errorf("source archive file not provided, use '--source' to specify the source archive")
+	}
+	if cc.destination == "" {
+		return fmt.Errorf("destination archive file not provided, use '--destination' to specify the output archive file")
+	}
+	if err := utils.CheckFileExistsPrompt(signalContext, cc.destination, cc.autoYes); err != nil {
+		return err
+	}
+	if err := cc.export(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cc *archiveExportCmd) export() error {
+	var images []string
+	file, err := os.Open(cc.file)
+	if err != nil {
+		return fmt.Errorf("failed to open %q: %w", cc.file, err)
+	}
+	sc := bufio.NewScanner(file)
+	sc.Split(bufio.ScanLines)
+	for sc.Scan() {
+		l := strings.TrimSpace(sc.Text())
+		if l == "" || strings.HasPrefix(l, "#") || strings.HasPrefix(l, "//") {
+			continue
+		}
+		images = append(images, l)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("failed to close %q: %w", cc.file, err)
+	}
+
+	ar, err := archive.NewReader(cc.source)
+	if err != nil {
+		return fmt.Errorf("failed to open archive: %w", err)
+	}
+	defer ar.Close()
+
+	aw, err := archive.NewWriter(cc.destination)
+	if err != nil {
+		return fmt.Errorf("failed to create archive: %w", err)
+	}
+	defer aw.Close()
+
+	ib, err := ar.Index()
+	if err != nil {
+		return fmt.Errorf("failed to read index from archive: %w", err)
+	}
+	index := archive.NewIndex()
+	index.Unmarshal(ib)
+	newIndex := archive.NewIndex()
+	failed := make([]string, 0)
+
+	for _, line := range images {
+		registry := utils.GetRegistryName(line)
+		if cc.sourceRegistry != "" {
+			registry = cc.sourceRegistry
+		}
+		project := utils.GetProjectName(line)
+		name := utils.GetImageName(line)
+		tag := utils.GetImageTag(line)
+		imageSource := fmt.Sprintf("%s/%s/%s", registry, project, name)
+		var image *archive.Image
+		for _, i := range index.List {
+			if !(i.Source == imageSource && i.Tag == tag) {
+				continue
+			}
+			image = i
+		}
+		if image == nil {
+			logrus.Errorf("Failed to export image [%v]: image not found in archive file", line)
+			failed = append(failed, line)
+			continue
+		}
+		err := aw.CopyImage(image, ar)
+		if err != nil {
+			logrus.Warnf("Error occured when copy image [%v:%v]", image.Source, image.Tag)
+			return err
+		}
+		newIndex.Append(image)
+		logrus.Infof("Copy [%s:%s]", image.Source, image.Tag)
+	}
+	if err := aw.WriteIndex(newIndex); err != nil {
+		return fmt.Errorf("failed to write index: %w", err)
+	}
+	if len(failed) > 0 {
+		f, err := os.OpenFile(cc.failed, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to create %q: %w", cc.failed, err)
+		}
+		_, err = f.WriteString(strings.Join(failed, "\n"))
+		if err != nil {
+			return fmt.Errorf("failed to write %q: %w", cc.failed, err)
+		}
+		logrus.Infof("Export failed images saved to %q", cc.failed)
+	}
+
+	return nil
+}

--- a/pkg/commands/archiveLs.go
+++ b/pkg/commands/archiveLs.go
@@ -37,7 +37,7 @@ hangar archive ls -f SAVED_ARCHIVE.zip`,
 				logrus.Debugf("%v", utils.PrintObject(cmdconfig.Get("")))
 			}
 
-			if err := cc.run(); err != nil {
+			if err := cc.run(args); err != nil {
 				return err
 			}
 			return nil
@@ -53,9 +53,13 @@ hangar archive ls -f SAVED_ARCHIVE.zip`,
 	return cc
 }
 
-func (cc *archiveLsCmd) run() error {
+func (cc *archiveLsCmd) run(args []string) error {
 	if cc.file == "" {
-		return fmt.Errorf("file not provided, use '--file' to provide the Hangar archive file")
+		if len(args) > 0 {
+			cc.file = args[0]
+		} else {
+			return fmt.Errorf("file not provided, use '--file' to provide the Hangar archive file")
+		}
 	}
 
 	reader, err := archive.NewReader(cc.file)

--- a/pkg/commands/archiveMerge.go
+++ b/pkg/commands/archiveMerge.go
@@ -1,0 +1,136 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cnrancher/hangar/pkg/cmdconfig"
+	"github.com/cnrancher/hangar/pkg/hangar/archive"
+	"github.com/cnrancher/hangar/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type archiveMergeOpts struct {
+	files   []string
+	output  string
+	autoYes bool
+}
+
+type archiveMergeCmd struct {
+	*baseCmd
+	*archiveMergeOpts
+}
+
+func newArchiveMergeCmd() *archiveMergeCmd {
+	cc := &archiveMergeCmd{
+		archiveMergeOpts: &archiveMergeOpts{},
+	}
+
+	cc.baseCmd = newBaseCmd(&cobra.Command{
+		Use:   "merge",
+		Short: "Merge multiple hangar archive files into one new archive file",
+		Long:  "",
+		Example: `
+# Merge multiple archive files
+hangar archive merge \
+	--file ARCHIVE_1.zip \
+	--file ARCHIVE_2.zip \
+	--output MERGE_OUTPUT.zip'`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			initializeFlagsConfig(cmd, cmdconfig.DefaultProvider)
+			if cc.baseCmd.debug {
+				logrus.SetLevel(logrus.DebugLevel)
+				logrus.Debugf("debug output enabled")
+				logrus.Debugf("%v", utils.PrintObject(cmdconfig.Get("")))
+			}
+
+			if err := cc.run(); err != nil {
+				return err
+			}
+			return nil
+		},
+	})
+
+	flags := cc.baseCmd.cmd.Flags()
+	flags.StringSliceVarP(&cc.files, "file", "f", nil, "archive file path")
+	flags.StringVarP(&cc.output, "output", "o", "", "output archive file")
+	flags.BoolVarP(&cc.autoYes, "auto-yes", "y", false, "answer yes automatically (used in shell script)")
+
+	return cc
+}
+
+func (cc *archiveMergeCmd) run() error {
+	if len(cc.files) == 0 {
+		return fmt.Errorf("archive files not provided, use '--file' option to specify at least 2 archive files")
+	}
+	if len(cc.files) < 2 {
+		return fmt.Errorf("use '--file' option to specify at least 2 archive files")
+	}
+	if cc.output == "" {
+		return fmt.Errorf("output file not provided, use '--output' to specify the output file")
+	}
+	if err := cc.merge(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cc *archiveMergeCmd) merge() error {
+	var (
+		readers  []*archive.Reader
+		writer   *archive.Writer
+		err      error
+		newIndex = archive.NewIndex()
+	)
+	for _, fn := range cc.files {
+		if _, err := os.Stat(fn); err != nil {
+			return fmt.Errorf("stat %q: %w", fn, err)
+		}
+		ar, err := archive.NewReader(fn)
+		if err != nil {
+			return fmt.Errorf("failed to create reader for %q: %w", fn, err)
+		}
+		readers = append(readers, ar)
+		defer ar.Close()
+	}
+	if len(readers) == 0 {
+		return fmt.Errorf("no archive files to merge")
+	}
+	if err := utils.CheckFileExistsPrompt(signalContext, cc.output, cc.autoYes); err != nil {
+		return err
+	}
+	writer, err = archive.NewWriter(cc.output)
+	if err != nil {
+		return fmt.Errorf("failed to create writer for %q: %w", cc.output, err)
+	}
+	defer writer.Close()
+
+	for _, reader := range readers {
+		ib, err := reader.Index()
+		if err != nil {
+			return fmt.Errorf("failed to load index: %w", err)
+		}
+		i := archive.NewIndex()
+		if err := i.Unmarshal(ib); err != nil {
+			return fmt.Errorf("failed to read index data: %w", err)
+		}
+
+		for _, img := range i.List {
+			if err := writer.CopyImage(img, reader); err != nil {
+				return fmt.Errorf("failed to copy image [%v:%v]: %w", img.Source, img.Tag, err)
+			}
+			newIndex.Append(img)
+			logrus.Infof("Copy [%s:%s]", img.Source, img.Tag)
+		}
+	}
+
+	if err := writer.WriteIndex(newIndex); err != nil {
+		return fmt.Errorf("failed to write index to %q: %w", cc.output, err)
+	}
+	logrus.Infof("Merged archive files [%v] to %q", strings.Join(cc.files, ","), cc.output)
+
+	return nil
+}

--- a/pkg/commands/convertlist.go
+++ b/pkg/commands/convertlist.go
@@ -138,25 +138,8 @@ func (cc *convertListCmd) run() error {
 		convertedLines = append(convertedLines, outputLine)
 	}
 
-	_, err = os.Stat(cc.output)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-	} else {
-		var s string
-		fmt.Printf("File %q already exists! Overwrite? [y/N] ", cc.output)
-		if cc.autoYes {
-			fmt.Println("y")
-		} else {
-			if _, err := utils.Scanf(signalContext, "%s", &s); err != nil {
-				return err
-			}
-			if len(s) == 0 || s[0] != 'y' && s[0] != 'Y' {
-				logrus.Warnf("Abort.")
-				return fmt.Errorf("file %q already exists", cc.output)
-			}
-		}
+	if err := utils.CheckFileExistsPrompt(signalContext, cc.output, cc.autoYes); err != nil {
+		return err
 	}
 
 	file, err := os.OpenFile(cc.output, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)

--- a/pkg/commands/inspect.go
+++ b/pkg/commands/inspect.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/cnrancher/hangar/pkg/cmdconfig"
 	"github.com/cnrancher/hangar/pkg/manifest"
@@ -64,6 +65,16 @@ hangar inspect docker://docker.io/cnrancher/hangar:latest --raw`,
 func (cc *inspectCmd) run(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("image reference not provided")
+	}
+	switch {
+	case strings.HasPrefix(args[0], "docker:"):
+	case strings.HasPrefix(args[0], "docker-daemon:"):
+	case strings.HasPrefix(args[0], "docker-archive:"):
+	case strings.HasPrefix(args[0], "oci:"):
+	case strings.HasPrefix(args[0], "dir:"):
+	default:
+		args[0] = fmt.Sprintf("docker://%s", args[0])
+		logrus.Warnf("Image reference protocol not provided, use 'docker' as default: %v", args[0])
 	}
 
 	ctx := signalContext

--- a/pkg/commands/load.go
+++ b/pkg/commands/load.go
@@ -123,7 +123,7 @@ func (cc *loadCmd) prepareHangar() (hangar.Hangar, error) {
 	if cc.file != "" {
 		file, err := os.Open(cc.file)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open %q: %v", cc.file, err)
+			return nil, fmt.Errorf("failed to open %q: %w", cc.file, err)
 		}
 		sc := bufio.NewScanner(file)
 		sc.Split(bufio.ScanLines)
@@ -135,7 +135,7 @@ func (cc *loadCmd) prepareHangar() (hangar.Hangar, error) {
 			images = append(images, l)
 		}
 		if err := file.Close(); err != nil {
-			return nil, fmt.Errorf("failed to close %q: %v", cc.file, err)
+			return nil, fmt.Errorf("failed to close %q: %w", cc.file, err)
 		}
 	}
 
@@ -180,7 +180,7 @@ func (cc *loadCmd) prepareHangar() (hangar.Hangar, error) {
 		ArchiveName:         cc.source,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create loader: %v", err)
+		return nil, fmt.Errorf("failed to create loader: %w", err)
 	}
 	logrus.Infof("Arch List: [%v]", strings.Join(cc.arch, ","))
 	logrus.Infof("OS List: [%v]", strings.Join(cc.os, ","))

--- a/pkg/commands/save.go
+++ b/pkg/commands/save.go
@@ -60,28 +60,9 @@ hangar save \
 			if err != nil {
 				return err
 			}
-
-			if _, err = os.Stat(cc.destination); err != nil {
-				if !os.IsNotExist(err) {
-					return fmt.Errorf("failed to stat file [%v]: %w",
-						cc.destination, err)
-				}
-			} else {
-				fmt.Printf("File %q already exists! Overwrite? [y/N] ", cc.destination)
-				if cc.autoYes {
-					fmt.Println("y")
-				} else {
-					var s string
-					if _, err = utils.Scanf(signalContext, "%s", &s); err != nil {
-						return err
-					}
-					if len(s) == 0 || s[0] != 'y' && s[0] != 'Y' {
-						logrus.Warnf("Abort.")
-						return fmt.Errorf("file %q already exists", cc.destination)
-					}
-				}
+			if err := utils.CheckFileExistsPrompt(signalContext, cc.destination, cc.autoYes); err != nil {
+				return err
 			}
-
 			if err := run(h); err != nil {
 				return err
 			}

--- a/pkg/rancher/listgenerator/generator.go
+++ b/pkg/rancher/listgenerator/generator.go
@@ -146,11 +146,12 @@ func (g *Generator) generateFromChartURLs(ctx context.Context) error {
 	}
 	for url := range g.ChartURLs {
 		c := chartimages.Chart{
-			RancherVersion: g.RancherVersion,
-			OS:             chartimages.Linux,
-			Type:           g.ChartURLs[url].Type,
-			Branch:         g.ChartURLs[url].Branch,
-			URL:            url,
+			RancherVersion:  g.RancherVersion,
+			OS:              chartimages.Linux,
+			Type:            g.ChartURLs[url].Type,
+			Branch:          g.ChartURLs[url].Branch,
+			URL:             url,
+			InsecureSkipTLS: g.InsecureSkipVerify,
 		}
 		if err := c.FetchImages(ctx); err != nil {
 			return err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -329,6 +329,8 @@ func EnsureSemverValid(v string) (string, error) {
 }
 
 // SemverCompare compares two semvers
+//
+// The result will be 0 if a == b, -1 if a < b, or +1 if a > b.
 func SemverCompare(a, b string) (int, error) {
 	if a == "" || b == "" {
 		return 0, ErrVersionIsEmpty
@@ -475,4 +477,30 @@ func HTTPClientDoWithRetry(
 		Delay:    time.Microsecond * 100,
 	})
 	return resp, err
+}
+
+func CheckFileExistsPrompt(
+	ctx context.Context, name string, autoYes bool,
+) error {
+	_, err := os.Stat(name)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	var s string
+	fmt.Printf("File %q already exists! Overwrite? [y/N] ", name)
+	if autoYes {
+		fmt.Println("y")
+	} else {
+		if _, err := Scanf(ctx, "%s", &s); err != nil {
+			return err
+		}
+		if len(s) == 0 || s[0] != 'y' && s[0] != 'Y' {
+			return fmt.Errorf("file %q already exists", name)
+		}
+	}
+
+	return nil
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,7 +25,9 @@ fi
 if [[ -n "${COMMIT}" ]]; then
     BUILD_LDFAGS="${BUILD_LDFAGS} -X 'github.com/cnrancher/hangar/pkg/utils.GitCommit=${COMMIT}'"
 fi
-BUILD_LDFAGS="${BUILD_LDFAGS} -X 'github.com/cnrancher/hangar/pkg/utils.Version=${VERSION}'"
+if [[ "${VERSION}" != v0.0.0* ]] && [[ -n "${VERSION}" ]]; then
+    BUILD_LDFAGS="${BUILD_LDFAGS} -X 'github.com/cnrancher/hangar/pkg/utils.Version=${VERSION}'"
+fi
 
 if [[ -n "${DISABLE_CGO:-}" ]]; then
     export CGO_ENABLED=0

--- a/test/suite/test_generate-list.py
+++ b/test/suite/test_generate-list.py
@@ -13,7 +13,6 @@ def test_generate_list_help():
     check(run_hangar(["generate-list", "--help"]))
 
 
-@pytest.mark.skip(reason="v2.8.0-ent is not released yet")
 def test_generate_list_gc_28():
     check(run_hangar([
         "generate-list",
@@ -28,6 +27,15 @@ def test_generate_list_gc_28():
     print("......")
     f.close()
     os.remove("v2.8.0-ent-images.txt")
+
+    f = open("v2.8.0-ent-versions.txt", "r")
+    print("")
+    print("Generated k8s version list of 'v2.8.0-ent'")
+    for _ in range(0, 5):
+        print(f.readline(), end="")
+    print("......")
+    f.close()
+    os.remove("v2.8.0-ent-versions.txt")
 
 
 def test_generate_list_gc_28_dev():
@@ -46,6 +54,15 @@ def test_generate_list_gc_28_dev():
     f.close()
     os.remove("v2.8.0-ent-dev-images.txt")
 
+    f = open("v2.8.0-ent-versions.txt", "r")
+    print("")
+    print("Generated k8s version list of 'v2.8.0-ent'")
+    for _ in range(0, 5):
+        print(f.readline(), end="")
+    print("......")
+    f.close()
+    os.remove("v2.8.0-ent-versions.txt")
+
 
 def test_generate_list_28():
     check(run_hangar([
@@ -62,6 +79,15 @@ def test_generate_list_28():
     f.close()
     os.remove("v2.8.0-images.txt")
 
+    f = open("v2.8.0-versions.txt", "r")
+    print("")
+    print("Generated k8s version list of 'v2.8.0'")
+    for _ in range(0, 5):
+        print(f.readline(), end="")
+    print("......")
+    f.close()
+    os.remove("v2.8.0-versions.txt")
+
 
 def test_generate_list_28_dev():
     check(run_hangar([
@@ -77,3 +103,12 @@ def test_generate_list_28_dev():
     print("......")
     f.close()
     os.remove("v2.8.0-dev-images.txt")
+
+    f = open("v2.8.0-versions.txt", "r")
+    print("")
+    print("Generated k8s version list of 'v2.8.0'")
+    for _ in range(0, 5):
+        print(f.readline(), end="")
+    print("......")
+    f.close()
+    os.remove("v2.8.0-versions.txt")


### PR DESCRIPTION
## Issue
<!-- Link the related issue here. -->
https://github.com/cnrancher/hangar/issues/32

## Describe
<!-- A clear and concise description of this pull request. -->

1. Add the `merge/export` command for `hangar archive` subcommand.
1. Update the Kubernetes versions sort function of the `hangar generate-list` command.

<!--
## Testing

### Manual Test


### Validation Test


### Unit Test

-->