### PR TITLE
Add `archive store` functionalities.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,11 @@ jobs:
       - name: Install hangar test
         uses: ./.github/actions/install-hangar
         with:
-          version: v1.9.0
+          version: v1.9.1
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
       - name: Setup Docker Buildx
@@ -31,7 +31,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.63
+          version: v1.64
       - name: Verify
         run: |
           ./scripts/verify.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
       - dev*
 jobs:
   ci:
-    runs-on: org-cnrancher-runner-dind-x64
+    runs-on: ${{ github.repository_owner == 'cnrancher' && 'org-cnrancher-runner-dind-x64' || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -42,7 +42,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.63
+        version: v1.64
     - name: Verify
       run: |
         ./scripts/verify.sh
@@ -93,6 +93,6 @@ jobs:
     - name: Hangar Sign
       uses: ./.github/actions/hangar-sign
       with:
-        version: v1.9.0
+        version: v1.9.1
         images: |
           ${{ vars.TCR_REGISTRY }}/${{ vars.PUBLIC_REGISTRY_REPO }}/hangar:${{ github.ref_name }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 1.24.x
     - name: Login to DockerHub # Avoid Rate Limit
       uses: docker/login-action@v3
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.out
 *.converted
 *.tar.gz
+*.tgz
 *.zstd
 *.part*
 *.tar

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,6 +93,11 @@ issues:
       text: 'Expect WriteFile permissions to be 0600 or less'
       linters:
         - gosec
+    # Permit image blobs to 0644
+    - path: 'pkg/hangar/archive/oci/chart.go'
+      text: 'Expect WriteFile permissions to be 0600 or less'
+      linters:
+        - gosec
     # Permit cobra cmd as unused parameter
     - path: 'pkg/commands/*'
       text: "unused-parameter: parameter 'cmd' seems to be unused"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,7 +94,7 @@ issues:
       linters:
         - gosec
     # Permit image blobs to 0644
-    - path: 'pkg/hangar/archive/oci/chart.go'
+    - path: 'pkg/hangar/archive/oci/common.go'
       text: 'Expect WriteFile permissions to be 0600 or less'
       linters:
         - gosec

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <div align="center">
   <h1>Hangar</h1>
   <p>
-    <a href="https://build.opensuse.org/package/show/home:StarryWang/Hangar"><img alt="GitHub pre-release" src="https://build.opensuse.org/projects/home:StarryWang/packages/Hangar/badge.svg?type=default"></a>
+    <a href="https://build.opensuse.org/package/show/home:StarryWang/Hangar"><img src="https://build.opensuse.org/projects/home:StarryWang/packages/Hangar/badge.svg?type=default"></a>
+    <a href="https://aur.archlinux.org/packages/hangar"><img src="https://img.shields.io/aur/version/hangar"></a>
     <a href="https://goreportcard.com/report/github.com/cnrancher/hangar"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cnrancher/hangar"></a>
     <a href="https://github.com/cnrancher/hangar/releases"><img alt="GitHub release" src="https://img.shields.io/github/v/release/cnrancher/hangar?color=default&label=release&logo=github"></a>
     <a href="https://github.com/cnrancher/hangar/releases"><img alt="GitHub pre-release" src="https://img.shields.io/github/v/release/cnrancher/hangar?include_prereleases&label=pre-release&logo=github"></a>
@@ -11,8 +12,7 @@
 
 > English | [简体中文](https://hangar.cnrancher.com/zh/)
 
-
-Hangar is a command line utility for container images with following features:
+Hangar is a command line utility for container images with the following features:
 
 - Multi-platform container images.
 - Copy container images between registry servers.
@@ -26,11 +26,11 @@ Hangar is a command line utility for container images with following features:
 - Hangar is cross-platform and works in all Unix-like operating systems.
 - Hangar supports both [docker images](https://github.com/moby/docker-image-spec/blob/main/README.md) and [OCI images](https://github.com/opencontainers/image-spec).
 - Hangar supports copying/saving/loading/signing/scanning images in parallel to increase speed.
-- Hanagr is designed to export container images as archive files and import them into image repositories in Air-Gapped environments.
+- Hangar is designed to export container images as archive files and import them into image repositories in Air-Gapped environments.
 
 ## Getting started
 
-The getting started instruction of Hangar is available in [documentation](https://hangar.cnrancher.com/docs/v1.9/).
+For documentation, visit the [Hangar Documentation](https://hangar.cnrancher.com/docs/v1.9).
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/cnrancher/hangar
 
-go 1.23.5
-
-toolchain go1.23.6
+go 1.24
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/pkg/commands/archive.go
+++ b/pkg/commands/archive.go
@@ -45,6 +45,7 @@ hangar archive merge --help
 		newArchiveLsCmd(),
 		newArchiveMergeCmd(),
 		newArchiveExportCmd(),
+		newArchiveStoreCmd(),
 	)
 	return cc
 }

--- a/pkg/commands/archive.go
+++ b/pkg/commands/archive.go
@@ -43,6 +43,7 @@ hangar archive merge --help
 	// flags := cc.baseCmd.cmd.Flags()
 
 	addCommands(cc.cmd,
+		newArchiveInitCmd(),
 		newArchiveLsCmd(),
 		newArchiveMergeCmd(),
 		newArchiveExportCmd(),

--- a/pkg/commands/archive.go
+++ b/pkg/commands/archive.go
@@ -14,9 +14,10 @@ func newArchiveCmd() *archiveCmd {
 	cc := &archiveCmd{}
 
 	cc.baseCmd = newBaseCmd(&cobra.Command{
-		Use:   "archive",
-		Short: "Action for Hangar archive file",
-		Long:  "",
+		Use:     "archive",
+		Short:   "Action for Hangar archive file",
+		Aliases: []string{"a"},
+		Long:    "",
 		Example: `# Show images in archive file:
 hangar archive ls --help
 

--- a/pkg/commands/archive_export.go
+++ b/pkg/commands/archive_export.go
@@ -33,9 +33,10 @@ func newArchiveExportCmd() *archiveExportCmd {
 	}
 
 	cc.baseCmd = newBaseCmd(&cobra.Command{
-		Use:   "export",
-		Short: "Export images from hangar archive file into a new archive file",
-		Long:  "Export some images from hangar archive file into a new archive file by image list file.",
+		Use:     "export",
+		Short:   "Export images from hangar archive file into a new archive file",
+		Aliases: []string{"e"},
+		Long:    "Export some images from hangar archive file into a new archive file by image list file.",
 		Example: `
 # Export images from archive file
 hangar archive export \

--- a/pkg/commands/archive_export.go
+++ b/pkg/commands/archive_export.go
@@ -66,6 +66,8 @@ hangar archive export \
 	flags.StringVarP(&cc.failed, "failed", "", "export-failed.txt", "export failed image list file name")
 	flags.BoolVarP(&cc.autoYes, "auto-yes", "y", false, "answer yes automatically (used in shell script)")
 
+	addCommands(cc.cmd, newExportFileCmd())
+
 	return cc
 }
 

--- a/pkg/commands/archive_export_file.go
+++ b/pkg/commands/archive_export_file.go
@@ -1,0 +1,166 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/cnrancher/hangar/pkg/hangar/archive"
+	"github.com/cnrancher/hangar/pkg/hangar/archive/oci"
+	"github.com/cnrancher/hangar/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/registry"
+
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type exportFileOpts struct {
+	file    string // archive file name
+	name    string // custom file name
+	autoYes bool
+}
+
+type exportFileCmd struct {
+	*baseCmd
+	*exportFileOpts
+}
+
+func newExportFileCmd() *exportFileCmd {
+	cc := &exportFileCmd{
+		exportFileOpts: &exportFileOpts{},
+	}
+
+	cc.baseCmd = newBaseCmd(&cobra.Command{
+		Use:     "file",
+		Short:   "Extract the custom file from Hangar Archive",
+		Aliases: []string{"f"},
+		Long:    "",
+		Example: `# Extract the custom file from archive file
+hangar archive export file \
+	--name FILENAME \
+	--file ARCHIVE.zip`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			utils.SetupLogrus(cc.hideLogTime)
+			if cc.debug {
+				logrus.SetLevel(logrus.DebugLevel)
+				logrus.Debugf("Debug output enabled")
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cc.run(); err != nil {
+				return err
+			}
+			return nil
+		},
+	})
+
+	flags := cc.baseCmd.cmd.Flags()
+	flags.StringVarP(&cc.file, "file", "f", "", "hangar archive file")
+	flags.StringVarP(&cc.name, "name", "n", "", "file name to be extracted from archive file")
+	flags.BoolVarP(&cc.autoYes, "auto-yes", "y", false, "answer yes automatically (used in shell script)")
+
+	return cc
+}
+
+func (cc *exportFileCmd) run() error {
+	if cc.file == "" {
+		cc.cmd.Help()
+		return fmt.Errorf("hangar archive file not provided")
+	}
+	if cc.name == "" {
+		cc.cmd.Help()
+		return fmt.Errorf("file name not provided")
+	}
+	if err := utils.CheckFileExistsPrompt(signalContext, cc.name, cc.autoYes); err != nil {
+		return err
+	}
+
+	ar, err := archive.NewReader(cc.file)
+	if err != nil {
+		return fmt.Errorf("failed to open %q: %w", cc.file, err)
+	}
+	defer ar.Close()
+
+	b, err := ar.Index()
+	if err != nil {
+		return fmt.Errorf("failed to load index from archive: %w", err)
+	}
+	index := archive.NewIndex()
+	err = index.Unmarshal(b)
+	if err != nil {
+		return fmt.Errorf("failed to decode index: %v", err)
+	}
+	expectedSource := fmt.Sprintf("%v/%v/%v",
+		utils.DockerHubRegistry, oci.DefaultFileProject, cc.name)
+	var expectedImage *archive.Image
+	for _, image := range index.List {
+		if image.Source == expectedSource && image.Tag == utils.DefaultTag &&
+			len(image.ArchList) == 0 && len(image.OsList) == 0 {
+			expectedImage = image
+			break
+		}
+	}
+	if expectedImage == nil {
+		return fmt.Errorf("failed to find custom file %q from archive %v: %w",
+			cc.name, cc.file, os.ErrNotExist)
+	}
+	// Validate OCI image to be extracted
+	if len(expectedImage.Images) == 0 {
+		return fmt.Errorf("no OCI image found")
+	}
+	spec := expectedImage.Images[0]
+	if spec.MediaType != imgspecv1.MediaTypeImageManifest {
+		logrus.Warnf("Image %q does is not a custom file OCI image", expectedSource)
+		return fmt.Errorf("unexpected image mediaType %q, should be %q",
+			spec.MediaType, imgspecv1.MediaTypeImageManifest)
+	}
+	manifestLayerPath := filepath.Join(archive.SharedBlobDir, "sha256", spec.Digest.Encoded())
+	f, err := ar.LoadFile(manifestLayerPath)
+	if err != nil {
+		return fmt.Errorf("failed to load manifest %q from archive: %w", manifestLayerPath, err)
+	}
+	defer f.Close()
+
+	if b, err = io.ReadAll(f); err != nil {
+		return fmt.Errorf("failed to read manifest %q from archive: %w", manifestLayerPath, err)
+	}
+	manifest := &imgspecv1.Manifest{}
+	if err := json.Unmarshal(b, manifest); err != nil {
+		return fmt.Errorf("failed to decode manifest: %w", err)
+	}
+	if len(manifest.Layers) == 0 {
+		return fmt.Errorf("image %q does not have layers", expectedSource)
+	}
+	layer := manifest.Layers[0]
+	if layer.MediaType != oci.FileLayerMediaType {
+		logrus.Warnf("Layer %q mediaType is %q",
+			layer.Digest, layer.MediaType)
+		if layer.MediaType == registry.ChartLayerMediaType || layer.MediaType == registry.ProvLayerMediaType {
+			logrus.Warnf("Image %q is a Helm Chart, not a Custom File", expectedSource)
+			logrus.Warnf("Use 'helm pull oci://<IMAGE>' command to pull OCI Helm Charts")
+		}
+		return fmt.Errorf("unexpected image layer mediaType: %q, should be %q",
+			layer.MediaType, oci.FileLayerMediaType)
+	}
+	fileLayerPath := filepath.Join(archive.SharedBlobDir, "sha256", layer.Digest.Encoded())
+	layerFile, err := ar.LoadFile(fileLayerPath)
+	if err != nil {
+		return fmt.Errorf("failed to load layer file %q from archive: %w", fileLayerPath, err)
+	}
+	defer layerFile.Close()
+	file, err := os.Create(cc.name)
+	if err != nil {
+		return fmt.Errorf("failed to create %q: %w", cc.name, err)
+	}
+	defer file.Close()
+
+	if _, err = io.Copy(file, layerFile); err != nil {
+		return fmt.Errorf("failed to write %q: %w", file.Name(), err)
+	}
+	logrus.Infof("Load [%v]", file.Name())
+
+	return nil
+}

--- a/pkg/commands/archive_init.go
+++ b/pkg/commands/archive_init.go
@@ -1,0 +1,65 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cnrancher/hangar/pkg/hangar/archive"
+	"github.com/cnrancher/hangar/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type archiveInitCmd struct {
+	*baseCmd
+}
+
+func newArchiveInitCmd() *archiveInitCmd {
+	cc := &archiveInitCmd{}
+	cc.baseCmd = newBaseCmd(&cobra.Command{
+		Use:     "init",
+		Short:   "Init an empty Archive file",
+		Long:    "Init an empty Archive file for use by sync/archive-store commands.",
+		Aliases: []string{"i"},
+		Example: `hangar archive init ./ARCHIVE_NAME.zip`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			utils.SetupLogrus(cc.hideLogTime)
+			if cc.debug {
+				logrus.SetLevel(logrus.DebugLevel)
+				logrus.Debugf("Debug output enabled")
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cc.run(args); err != nil {
+				return err
+			}
+			return nil
+		},
+	})
+
+	return cc
+}
+
+func (cc *archiveInitCmd) run(args []string) error {
+	if len(args) == 0 {
+		cc.cmd.Help()
+		return fmt.Errorf("archive filename not provided")
+	}
+
+	for _, a := range args {
+		_, err := os.Stat(a)
+		if err == nil {
+			return fmt.Errorf("file %q already exists", a)
+		}
+
+		aw, err := archive.NewWriter(a)
+		if err != nil {
+			return fmt.Errorf("failed to create archive writer: %w", err)
+		}
+
+		aw.WriteIndex(archive.NewIndex())
+		aw.Close()
+		logrus.Infof("Create [%v]", a)
+	}
+	return nil
+}

--- a/pkg/commands/archive_merge.go
+++ b/pkg/commands/archive_merge.go
@@ -28,9 +28,10 @@ func newArchiveMergeCmd() *archiveMergeCmd {
 	}
 
 	cc.baseCmd = newBaseCmd(&cobra.Command{
-		Use:   "merge",
-		Short: "Merge multiple hangar archive files into one new archive file",
-		Long:  "",
+		Use:     "merge",
+		Aliases: []string{"m"},
+		Short:   "Merge multiple hangar archive files into one new archive file",
+		Long:    "",
 		Example: `
 # Merge multiple archive files
 hangar archive merge \

--- a/pkg/commands/archive_store.go
+++ b/pkg/commands/archive_store.go
@@ -11,9 +11,10 @@ type archiveStoreCmd struct {
 func newArchiveStoreCmd() *archiveStoreCmd {
 	cc := &archiveStoreCmd{}
 	cc.baseCmd = newBaseCmd(&cobra.Command{
-		Use:   "store",
-		Short: "store files in Hangar archive file",
-		Long:  "",
+		Use:     "store",
+		Short:   "store files in Hangar archive file",
+		Aliases: []string{"s"},
+		Long:    "",
 		Example: `# Store chart file into hangar archive file
 hangar archive store chart --help
 

--- a/pkg/commands/archive_store.go
+++ b/pkg/commands/archive_store.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type archiveStoreCmd struct {
+	*baseCmd
+}
+
+func newArchiveStoreCmd() *archiveStoreCmd {
+	cc := &archiveStoreCmd{}
+	cc.baseCmd = newBaseCmd(&cobra.Command{
+		Use:   "store",
+		Short: "store files in Hangar archive file",
+		Long:  "",
+		Example: `# Store chart file into hangar archive file
+hangar archive store chart --help
+
+# Store files into hangar archive file
+hangar archive store file --help
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cc.cmd.Help()
+		},
+	})
+
+	addCommands(cc.cmd,
+		newStoreChartCmd(),
+		newStoreFileCmd())
+	return cc
+}

--- a/pkg/commands/archive_store_chart.go
+++ b/pkg/commands/archive_store_chart.go
@@ -1,0 +1,98 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/cnrancher/hangar/pkg/hangar/archive"
+	"github.com/cnrancher/hangar/pkg/hangar/archive/oci"
+	"github.com/cnrancher/hangar/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type storeChartOpts struct {
+	file      string
+	name      string
+	version   string
+	tlsVerify bool
+}
+
+type storeChartCmd struct {
+	*baseCmd
+	*storeChartOpts
+}
+
+func newStoreChartCmd() *storeChartCmd {
+	cc := &storeChartCmd{
+		storeChartOpts: new(storeChartOpts),
+	}
+	cc.baseCmd = newBaseCmd(&cobra.Command{
+		Use:     "chart",
+		Short:   "store helm chart in Hangar archive file",
+		Long:    "",
+		Example: ``,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			utils.SetupLogrus(cc.hideLogTime)
+			if cc.debug {
+				logrus.SetLevel(logrus.DebugLevel)
+				logrus.Debugf("Debug output enabled")
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cc.run(args); err != nil {
+				return err
+			}
+			return nil
+		},
+	})
+
+	flags := cc.baseCmd.cmd.Flags()
+	flags.StringVarP(&cc.file, "file", "f", "", "Path to the Hangar archive file (.zip)")
+	flags.StringVarP(&cc.version, "version", "v", "", "Chart version (optional)")
+	flags.StringVarP(&cc.name, "name", "n", "", "Chart name of the helm repository")
+	flags.BoolVarP(&cc.tlsVerify, "tls-verify", "", true, "Require HTTPS and verify certificates")
+
+	return cc
+}
+
+func (cc *storeChartCmd) run(args []string) error {
+	if len(args) == 0 {
+		cc.cmd.Help()
+		return fmt.Errorf("helm chart not provided")
+	}
+	if cc.file == "" {
+		return fmt.Errorf("archive file not provided")
+	}
+
+	policy, err := cc.getPolicy()
+	if err != nil {
+		return fmt.Errorf("failed to get policy: %w", err)
+	}
+	au, err := archive.NewUpdater(cc.file)
+	if err != nil {
+		return err
+	}
+	defer au.Close()
+
+	for _, a := range args {
+		chart := oci.NewChart(&oci.ChartOptions{
+			URL:                a,
+			Name:               cc.name,
+			Version:            cc.version,
+			InsecureSkipVerify: !cc.tlsVerify,
+			SystemContext:      cc.baseCmd.newSystemContext(),
+			Policy:             policy,
+		})
+		logrus.Infof("Fetching chart %q", a)
+		if err := chart.Fetch(signalContext); err != nil {
+			return fmt.Errorf("failed to fetch %q, name %q, version %q: %w",
+				a, cc.name, cc.version, err)
+		}
+		if err := chart.WriteArchive(au); err != nil {
+			return fmt.Errorf("failed to write chart %q to archive: %w",
+				chart.CacheDir(), err)
+		}
+		logrus.Infof("Store chart %q", chart.Source())
+	}
+	return nil
+}

--- a/pkg/commands/archive_store_file.go
+++ b/pkg/commands/archive_store_file.go
@@ -3,22 +3,42 @@ package commands
 import (
 	"fmt"
 
+	"github.com/cnrancher/hangar/pkg/hangar/archive"
+	"github.com/cnrancher/hangar/pkg/hangar/archive/oci"
 	"github.com/cnrancher/hangar/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
+type storeFileOpts struct {
+	file      string
+	tlsVerify bool
+}
+
 type storeFile struct {
 	*baseCmd
+	*storeFileOpts
 }
 
 func newStoreFileCmd() *storeFile {
-	cc := &storeFile{}
+	cc := &storeFile{
+		storeFileOpts: new(storeFileOpts),
+	}
 	cc.baseCmd = newBaseCmd(&cobra.Command{
 		Use:     "file",
-		Short:   "store file in Hangar archive file",
+		Short:   "Store OCI format Custom File in archive (Experimental)",
+		Aliases: []string{"files", "f"},
 		Long:    "",
-		Example: ``,
+		Example: `# Add files to archive
+hangar archive store file \
+	--file saved_images.zip \
+	./path/to/file1.txt \
+	./path/to/file2.txt \
+
+# Add file from URL
+hangar archive store file \
+	--file saved_images.zip \
+	https://example.com/path/to/file.txt`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			utils.SetupLogrus(cc.hideLogTime)
 			if cc.debug {
@@ -35,7 +55,8 @@ func newStoreFileCmd() *storeFile {
 	})
 
 	flags := cc.baseCmd.cmd.Flags()
-	_ = flags
+	flags.StringVarP(&cc.file, "file", "f", "", "Path to the Hangar archive file (zip)")
+	flags.BoolVarP(&cc.tlsVerify, "tls-verify", "", true, "Require HTTPS and verify certificates")
 
 	return cc
 }
@@ -45,5 +66,39 @@ func (cc *storeFile) run(args []string) error {
 		cc.cmd.Help()
 		return fmt.Errorf("file not provided")
 	}
+	if cc.file == "" {
+		return fmt.Errorf("archive file not provided")
+	}
+
+	policy, err := cc.getPolicy()
+	if err != nil {
+		return fmt.Errorf("failed to get policy: %w", err)
+	}
+	au, err := archive.NewUpdater(cc.file)
+	if err != nil {
+		return err
+	}
+	defer au.Close()
+
+	for _, a := range args {
+		file := oci.NewFile(&oci.FileOptions{
+			CommonOpts: oci.CommonOpts{
+				InsecureSkipVerify: !cc.tlsVerify,
+				SystemContext:      cc.baseCmd.newSystemContext(),
+				Policy:             policy,
+			},
+			URL: a,
+		})
+		if err := file.Fetch(signalContext); err != nil {
+			return fmt.Errorf("failed to add %q: %w",
+				a, err)
+		}
+		if err := file.WriteArchive(au); err != nil {
+			return fmt.Errorf("failed to write OCI image path %q to archive: %w",
+				file.CacheDir(), err)
+		}
+		logrus.Infof("Add OCI File [%v]", file.Source())
+	}
+
 	return nil
 }

--- a/pkg/commands/archive_store_file.go
+++ b/pkg/commands/archive_store_file.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/cnrancher/hangar/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type storeFile struct {
+	*baseCmd
+}
+
+func newStoreFileCmd() *storeFile {
+	cc := &storeFile{}
+	cc.baseCmd = newBaseCmd(&cobra.Command{
+		Use:     "file",
+		Short:   "store file in Hangar archive file",
+		Long:    "",
+		Example: ``,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			utils.SetupLogrus(cc.hideLogTime)
+			if cc.debug {
+				logrus.SetLevel(logrus.DebugLevel)
+				logrus.Debugf("Debug output enabled")
+			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cc.run(args); err != nil {
+				return err
+			}
+			return nil
+		},
+	})
+
+	flags := cc.baseCmd.cmd.Flags()
+	_ = flags
+
+	return cc
+}
+
+func (cc *storeFile) run(args []string) error {
+	if len(args) == 0 {
+		cc.cmd.Help()
+		return fmt.Errorf("file not provided")
+	}
+	return nil
+}

--- a/pkg/commands/archive_store_file.go
+++ b/pkg/commands/archive_store_file.go
@@ -26,7 +26,7 @@ func newStoreFileCmd() *storeFile {
 	}
 	cc.baseCmd = newBaseCmd(&cobra.Command{
 		Use:     "file",
-		Short:   "Store OCI format Custom File in archive (Experimental)",
+		Short:   "Store OCI format Custom File in archive",
 		Aliases: []string{"files", "f"},
 		Long:    "",
 		Example: `# Add files to archive

--- a/pkg/commands/generate_list.go
+++ b/pkg/commands/generate_list.go
@@ -109,7 +109,7 @@ You can also download the KDM JSON file and clone chart repos manually:
 	flags.StringVarP(&cc.rke2Images, "rke2-images", "", "", "output KDM RKE2 linux image list if specified")
 	flags.StringVarP(&cc.rke2WindowsImages, "rke2-windows-images", "", "", "output KDM RKE2 Windows image list if specified")
 	flags.StringVarP(&cc.k3sImages, "k3s-images", "", "", "output KDM K3s linux image list if specified")
-	flags.BoolVarP(&cc.tlsVerify, "tls-verify", "", false, "require HTTPS and verify certificates")
+	flags.BoolVarP(&cc.tlsVerify, "tls-verify", "", true, "require HTTPS and verify certificates")
 	flags.BoolVarP(&cc.autoYes, "auto-yes", "y", false, "answer yes automatically (used in shell script)")
 
 	return cc

--- a/pkg/commands/inspect.go
+++ b/pkg/commands/inspect.go
@@ -27,7 +27,7 @@ func newInspectCmd() *inspectCmd {
 	cc := &inspectCmd{}
 
 	cc.baseCmd = newBaseCmd(&cobra.Command{
-		Use:     "inspect IMAGR_REFERENCE",
+		Use:     "inspect IMAGE_REFERENCE",
 		Aliases: []string{"i"},
 		Short:   "Inspect provides basic functions of 'skopeo inspect' to inspect image manifest",
 		Long:    "",

--- a/pkg/commands/inspect.go
+++ b/pkg/commands/inspect.go
@@ -27,9 +27,10 @@ func newInspectCmd() *inspectCmd {
 	cc := &inspectCmd{}
 
 	cc.baseCmd = newBaseCmd(&cobra.Command{
-		Use:   "inspect IMAGR_REFERENCE",
-		Short: "Inspect provides basic functions of 'skopeo inspect' to inspect image manifest",
-		Long:  "",
+		Use:     "inspect IMAGR_REFERENCE",
+		Aliases: []string{"i"},
+		Short:   "Inspect provides basic functions of 'skopeo inspect' to inspect image manifest",
+		Long:    "",
 		Example: `# Inspect image manifest:
 hangar inspect [image-reference]
 

--- a/pkg/commands/load.go
+++ b/pkg/commands/load.go
@@ -46,8 +46,9 @@ func newLoadCmd() *loadCmd {
 		loadOpts: new(loadOpts),
 	}
 	cc.baseCmd = newBaseCmd(&cobra.Command{
-		Use:   "load -s SAVED_ARCHIVE.zip -d REGISTRY_SERVER",
-		Short: "Load images from zip archive created by 'save' command to registry server",
+		Use:     "load -s SAVED_ARCHIVE.zip -d REGISTRY_SERVER",
+		Aliases: []string{"l"},
+		Short:   "Load images from zip archive created by 'save' command to registry server",
 		Long: `Load images from zip archive created by 'save' command to registry server.
 
 The load command will create Harbor V2 projects for destination registry automatically.

--- a/pkg/commands/mirror.go
+++ b/pkg/commands/mirror.go
@@ -49,9 +49,10 @@ func newMirrorCmd() *mirrorCmd {
 		mirrorOpts: new(mirrorOpts),
 	}
 	cc.baseCmd = newBaseCmd(&cobra.Command{
-		Use:   "mirror -f IMAGE_LIST.txt -d DESTINATION_REGISTRY",
-		Short: "Mirror images between registry servers",
-		Long:  ``,
+		Use:     "mirror -f IMAGE_LIST.txt -d DESTINATION_REGISTRY",
+		Aliases: []string{"m"},
+		Short:   "Mirror images between registry servers",
+		Long:    ``,
 		Example: `# Mirror images from SOURCE REGISTRY to DESTINATION REGISTRY.
 hangar mirror \
 	--file IMAGE_LIST.txt \

--- a/pkg/commands/save.go
+++ b/pkg/commands/save.go
@@ -39,9 +39,10 @@ func newSaveCmd() *saveCmd {
 		saveOpts: new(saveOpts),
 	}
 	cc.baseCmd = newBaseCmd(&cobra.Command{
-		Use:   "save -f IMAGE_LIST.txt -d SAVED_ARCHIVE.zip",
-		Short: "Save images from registry server into local archive file",
-		Long:  "",
+		Use:     "save -f IMAGE_LIST.txt -d SAVED_ARCHIVE.zip",
+		Aliases: []string{"s"},
+		Short:   "Save images from registry server into local archive file",
+		Long:    "",
 		Example: `
 hangar save \
 	--file IMAGE_LIST.txt \

--- a/pkg/commands/sign_v2.go
+++ b/pkg/commands/sign_v2.go
@@ -39,8 +39,6 @@ type signOpts struct {
 	passphraseFile          string
 	signManifestIndex       bool
 	tlogUpload              bool
-	issueCertificate        bool
-	signContainerIdentity   string
 	recordCreationTimestamp bool
 	rekorURL                string
 	fulcioURL               string

--- a/pkg/hangar/archive/oci/chart.go
+++ b/pkg/hangar/archive/oci/chart.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -21,159 +22,68 @@ import (
 	"github.com/cnrancher/hangar/pkg/image/types"
 	"github.com/cnrancher/hangar/pkg/rancher/chartimages"
 	"github.com/cnrancher/hangar/pkg/utils"
-	"github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/specs-go"
 	"github.com/sirupsen/logrus"
+	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/repo"
 
-	signaturev5 "github.com/containers/image/v5/signature"
-	typesv5 "github.com/containers/image/v5/types"
+	"github.com/opencontainers/go-digest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+const (
+	DefaultChartProject = "hangar-helm"
+)
+
 type Chart struct {
+	common
+
 	url     string
 	name    string
 	version string
-
-	insecureSkipVerify bool
-	systemContext      *typesv5.SystemContext
-	policy             *signaturev5.Policy
-
-	cacheDir    string
-	imageDir    string
-	imageSource string
 }
 
 type ChartOptions struct {
+	CommonOpts
 	URL     string
 	Name    string
 	Version string
-
-	InsecureSkipVerify bool
-	SystemContext      *typesv5.SystemContext
-	Policy             *signaturev5.Policy
 }
 
 func NewChart(opts *ChartOptions) *Chart {
 	return &Chart{
-		url:                opts.URL,
-		name:               opts.Name,
-		version:            opts.Version,
-		insecureSkipVerify: opts.InsecureSkipVerify,
-		systemContext:      utils.CopySystemContext(opts.SystemContext),
-		policy:             opts.Policy,
+		common: common{
+			insecureSkipVerify: opts.CommonOpts.InsecureSkipVerify,
+			systemContext:      utils.CopySystemContext(opts.CommonOpts.SystemContext),
+			policy:             opts.CommonOpts.Policy,
+		},
+		url:     opts.URL,
+		name:    opts.Name,
+		version: opts.Version,
 	}
 }
 
 // Fetch chart from remote URL or local directory and convert it to OCI image.
-// Need to use [Chart.Cleanup] method manually to delete the cache directory.
+// Need to use [common.Cleanup] method manually to delete the cache directory.
 func (c *Chart) Fetch(ctx context.Context) error {
 	mode, err := os.Stat(c.url)
 	switch {
-	case err == nil && mode.IsDir():
-		return c.fromDirectory()
+	case err == nil:
+		if mode.IsDir() {
+			return c.fromDirectory()
+		}
+		return c.fromFile()
 	case registry.IsOCI(c.url):
 		return c.fromOCI(ctx)
 	case strings.HasPrefix(c.url, "http://") || strings.HasPrefix(c.url, "https://"):
 		if strings.HasSuffix(c.url, ".tgz") || strings.HasSuffix(c.url, ".tar.gz") {
-			return c.fromURL(ctx)
+			return c.fromURL(ctx, c.url)
 		}
 		return c.fromRepo(ctx)
 	default:
-		return fmt.Errorf("invalid URL format %q", c.url)
+		return fmt.Errorf("invalid chart %q: %w", c.url, err)
 	}
-}
-
-func (c *Chart) CacheDir() string {
-	return c.cacheDir
-}
-
-func (c *Chart) ImageDir() string {
-	return c.imageDir
-}
-
-func (c *Chart) image() (*archive.Image, error) {
-	inspector, err := manifest.NewInspector(context.TODO(), &manifest.InspectorOption{
-		ReferenceName: fmt.Sprintf("oci:%v", c.imageDir),
-		SystemContext: utils.SystemContextWithSharedBlobDir(
-			c.systemContext, filepath.Join(c.cacheDir, archive.SharedBlobDir)),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create inspector from dir %q: %w",
-			c.imageDir, err)
-	}
-	defer inspector.Close()
-	// Use background context to inspect local directory
-	b, mime, err := inspector.Raw(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("failed to inspect dir %q: %w",
-			c.imageDir, err)
-	}
-	manifestDigest := digest.SHA256.FromBytes(b)
-	if mime != imgspecv1.MediaTypeImageManifest {
-		return nil, fmt.Errorf("image MIME type should be OCI image manifest v1, got %q", mime)
-	}
-	manifest := &imgspecv1.Manifest{}
-	if err := json.Unmarshal(b, manifest); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
-	}
-	spec := archive.ImageSpec{
-		Arch:        "",
-		OS:          "",
-		OSVersion:   "",
-		OSFeatures:  nil,
-		Variant:     "",
-		MediaType:   mime,
-		Layers:      nil,
-		Config:      manifest.Config.Digest,
-		Digest:      manifestDigest,
-		Annotations: manifest.Annotations,
-	}
-	for _, layer := range manifest.Layers {
-		spec.Layers = append(spec.Layers, layer.Digest)
-	}
-	image := &archive.Image{
-		Source:   c.Source(),
-		Tag:      c.version,
-		ArchList: make([]string, 0),
-		OsList:   make([]string, 0),
-		Images:   []archive.ImageSpec{spec},
-	}
-	return image, nil
-}
-
-func (c *Chart) Source() string {
-	return c.imageSource
-}
-
-// WriteArchive writes chart OCI image into the archive file.
-func (c *Chart) WriteArchive(au *archive.Updater) error {
-	if c.cacheDir == "" {
-		return fmt.Errorf("chart is not fetched to the cache directory")
-	}
-	err := au.Append(c.cacheDir)
-	if err != nil {
-		return fmt.Errorf("write dir %q to archive file: %w",
-			c.cacheDir, err)
-	}
-	index := au.Index()
-	image, err := c.image()
-	if err != nil {
-		return err
-	}
-	index.Append(image)
-	au.SetIndex(index)
-	return au.UpdateIndex()
-}
-
-func (c *Chart) Cleanup() error {
-	if c.cacheDir == "" {
-		return nil
-	}
-	return os.RemoveAll(c.cacheDir)
 }
 
 func (c *Chart) fromOCI(ctx context.Context) error {
@@ -207,7 +117,6 @@ func (c *Chart) fromOCI(ctx context.Context) error {
 	}
 	c.cacheDir = cd
 	c.imageDir = filepath.Join(c.cacheDir, src.ManifestDigest().Encoded())
-	c.imageSource = image
 	sd := filepath.Join(cd, archive.SharedBlobDir)
 	dest, err := destination.NewDestination(&destination.Option{
 		Type:      types.TypeOci,
@@ -237,6 +146,36 @@ func (c *Chart) fromOCI(ctx context.Context) error {
 		return fmt.Errorf("failed to copy image %q to %q: %w",
 			src.ReferenceName(), dest.ReferenceName(), err)
 	}
+
+	inspector, err := manifest.NewInspector(ctx, &manifest.InspectorOption{
+		ReferenceName: fmt.Sprintf("oci:%v", filepath.Join(c.cacheDir, src.ManifestDigest().Encoded())),
+		SystemContext: dest.SystemContext(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create dest image inspector: %w", err)
+	}
+	b, _, err := inspector.Raw(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to inspect dest image: %w", err)
+	}
+	destManifest := &imgspecv1.Manifest{}
+	if err := json.Unmarshal(b, destManifest); err != nil {
+		return fmt.Errorf("failed to unmarshal dest image manifest: %w", err)
+	}
+	c.manifestDigest = digest.SHA256.FromBytes(b)
+	c.configDigest = destManifest.Config.Digest
+	c.annotations = destManifest.Annotations
+	for _, l := range destManifest.Layers {
+		c.layers = append(c.layers, l.Digest)
+	}
+	c.imageTag = c.version
+	if c.imageTag == "" {
+		c.imageTag = utils.DefaultTag
+	}
+	c.imageSource = fmt.Sprintf("%v/%v/%v",
+		utils.GetRegistryName(image),
+		utils.GetProjectName(image),
+		utils.GetImageName(image))
 	return nil
 }
 
@@ -294,9 +233,15 @@ func (c *Chart) fromRepo(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get chart URL: %w", err)
 	}
-	c.imageSource = chartURL
-	c.cacheDir, c.imageDir, err = fromURL(ctx, chartURL, c.insecureSkipVerify)
-	return err
+	return c.fromURL(ctx, chartURL)
+}
+
+func (c *Chart) fromFile() error {
+	f, err := os.Open(c.url)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	return c.fromReader(f)
 }
 
 func (c *Chart) fromDirectory() error {
@@ -317,171 +262,69 @@ func (c *Chart) fromDirectory() error {
 		return fmt.Errorf("failed to open chart file %q", chartPath)
 	}
 	defer f.Close()
-	c.imageSource = chartPath
-	c.cacheDir, c.imageDir, err = fromReader(f)
-	return err
+	return c.fromReader(f)
 }
 
-func (c *Chart) fromURL(ctx context.Context) error {
+func (c *Chart) fromURL(ctx context.Context, url string) error {
+	logrus.Debugf("Get helm chart from %q", c.url)
 	var err error
-	c.imageSource = c.url
-	c.cacheDir, c.imageDir, err = fromURL(ctx, c.url, c.insecureSkipVerify)
-	return err
-}
 
-func fromURL(
-	ctx context.Context, url string, insecureSkipVerify bool,
-) (cache string, image string, err error) {
-	logrus.Debugf("Get helm chart from %q", url)
 	client := &http.Client{
 		Timeout: time.Second * 30,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: c.insecureSkipVerify},
 			Proxy:           http.ProxyFromEnvironment,
 		},
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create http request: %w", err)
+		return fmt.Errorf("failed to create http request: %w", err)
 	}
 	resp, err := utils.HTTPClientDoWithRetry(ctx, client, req)
 	if err != nil {
-		return "", "", fmt.Errorf("http request failed: %w", err)
+		return fmt.Errorf("http request failed: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		return "", "", fmt.Errorf("failed to get url %q: %v", url, resp.Status)
+		return fmt.Errorf("failed to get url %q: %v", c.url, resp.Status)
 	}
-	cache, image, err = fromReader(resp.Body)
-	return
+	return c.fromReader(resp.Body)
 }
 
-func fromReader(r io.Reader) (cache string, image string, err error) {
-	layerData, err := io.ReadAll(r)
+// fromReader constructs the Hangar OCI format Chart image into
+// the cache directory from [io.Reader].
+func (c *Chart) fromReader(r io.Reader) (err error) {
+	var buffer bytes.Buffer
+	teeReader := io.TeeReader(r, &buffer)
+	chart, err := loadChartFromReader(teeReader)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to fetch chart data: %w", err)
+		return fmt.Errorf("load chart: %w", err)
 	}
-	cd, err := newFileCacheDir()
-	if err != nil {
-		return "", "", err
+	metadata := chart.Metadata
+	c.annotations = map[string]string{
+		imgspecv1.AnnotationVendor:      utils.Name,
+		imgspecv1.AnnotationCreated:     time.Now().Format(time.RFC3339),
+		imgspecv1.AnnotationURL:         metadata.Home,
+		imgspecv1.AnnotationVersion:     metadata.Version,
+		imgspecv1.AnnotationTitle:       metadata.Name,
+		imgspecv1.AnnotationDescription: metadata.Description,
 	}
-
-	layerDigest := digest.SHA256.FromBytes(layerData)
-	tmpChartName := fmt.Sprintf("sha256-%x.tgz", layerDigest.Encoded())
-	tmpChartPath := filepath.Join(cd, tmpChartName)
-	f, err := os.Create(tmpChartPath)
-	if err != nil {
-		return cd, "", fmt.Errorf("failed to create %q: %w", tmpChartPath, err)
+	c.config = metadata
+	c.layerMediaType = registry.ChartLayerMediaType
+	c.name = metadata.Name
+	c.imageSource = fmt.Sprintf("%v/%v/%v",
+		utils.DockerHubRegistry, DefaultChartProject, metadata.Name)
+	c.imageTag = metadata.Version
+	if c.imageTag == "" {
+		c.imageTag = utils.DefaultTag
 	}
-	defer f.Close()
-	_, err = f.Write(layerData)
-	if err != nil {
-		return cd, "", fmt.Errorf("failed to write %q: %w", tmpChartPath, err)
+	c.imageTag = strings.ReplaceAll(c.imageTag, "+", "-")
+	if err := c.constructOCIImage(&buffer); err != nil {
+		return fmt.Errorf("failed to construct OCI image from file %q: %w",
+			c.url, err)
 	}
-
-	c, err := loader.Load(tmpChartPath)
-	if err != nil {
-		return cd, "", fmt.Errorf("failed to load chart: %w", err)
-	}
-	configData, err := json.MarshalIndent(c.Metadata, "", "  ")
-	if err != nil {
-		return cd, "", fmt.Errorf("failed to marshal chart metadata: %w", err)
-	}
-	configDigest := digest.SHA256.FromBytes(configData)
-
-	m := &imgspecv1.Manifest{
-		Versioned: specs.Versioned{
-			SchemaVersion: 2,
-		},
-		MediaType: imgspecv1.MediaTypeImageManifest,
-		Config: imgspecv1.Descriptor{
-			MediaType: registry.ConfigMediaType,
-			Size:      int64(len(configData)),
-			Digest:    configDigest,
-		},
-		Layers: []imgspecv1.Descriptor{
-			{
-				MediaType: registry.ChartLayerMediaType,
-				Size:      int64(len(layerData)),
-				Digest:    layerDigest,
-			},
-		},
-		Annotations: map[string]string{
-			imgspecv1.AnnotationURL:         c.Metadata.Home,
-			imgspecv1.AnnotationVersion:     c.Metadata.Version,
-			imgspecv1.AnnotationTitle:       c.Metadata.Name,
-			imgspecv1.AnnotationDescription: c.Metadata.Description,
-		},
-	}
-	manifestData, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return cd, "", fmt.Errorf("failed to marshal manifest: %w", err)
-	}
-	manifestDigest := digest.SHA256.FromBytes(manifestData)
-
-	// Construct chart file to containers OCI format
-	err = os.Mkdir(filepath.Join(cd, manifestDigest.Encoded()), 0755)
-	if err != nil {
-		return cd, "", fmt.Errorf("mkdir failed on %q: %w",
-			filepath.Join(cd, manifestDigest.Encoded()), err)
-	}
-	// Create share blobs path
-	sharedBlobPath := filepath.Join(cd, archive.SharedBlobDir, "sha256")
-	if err = os.MkdirAll(sharedBlobPath, 0755); err != nil {
-		return cd, "", fmt.Errorf("mkdir failed %q: %w", sharedBlobPath, err)
-	}
-	// Chart layer
-	if err = os.Rename(tmpChartPath,
-		filepath.Join(sharedBlobPath, layerDigest.Encoded())); err != nil {
-		return cd, "", fmt.Errorf("chart layer file rename failed: %w", err)
-	}
-	// Manifest file
-	if err = os.WriteFile(filepath.Join(sharedBlobPath, manifestDigest.Encoded()), manifestData, 0644); err != nil {
-		return cd, "", fmt.Errorf("failed to write manifest: %w", err)
-	}
-	// Config file
-	if err = os.WriteFile(filepath.Join(sharedBlobPath, configDigest.Encoded()), configData, 0644); err != nil {
-		return cd, "", fmt.Errorf("failed to write config: %w", err)
-	}
-	// OCI Image index
-	imagePath := filepath.Join(cd, manifestDigest.Encoded())
-	if err = os.MkdirAll(filepath.Join(imagePath, imgspecv1.ImageBlobsDir), 0755); err != nil {
-		return cd, "", fmt.Errorf("mkdir failed %q: %w", imagePath, err)
-	}
-	index := imgspecv1.Index{
-		Versioned: specs.Versioned{
-			SchemaVersion: 2,
-		},
-		Manifests: []imgspecv1.Descriptor{
-			{
-				MediaType: imgspecv1.MediaTypeImageManifest,
-				Digest:    manifestDigest,
-				Size:      int64(len(manifestData)),
-			},
-		},
-	}
-	indexData, err := json.Marshal(index)
-	if err != nil {
-		return cd, imagePath, fmt.Errorf("failed to marshal manifest index: %w", err)
-	}
-	if err := os.WriteFile(
-		filepath.Join(imagePath, imgspecv1.ImageIndexFile), indexData, 0644); err != nil {
-		return cd, imagePath, fmt.Errorf("failed to write manifest index: %w", err)
-	}
-	// Image Layout
-	layout := imgspecv1.ImageLayout{
-		Version: imgspecv1.ImageLayoutVersion,
-	}
-	layoutData, err := json.Marshal(layout)
-	if err != nil {
-		return cd, imagePath, fmt.Errorf("failed to marshal image layout: %w", err)
-	}
-	if err := os.WriteFile(
-		filepath.Join(imagePath, imgspecv1.ImageLayoutFile), layoutData, 0644); err != nil {
-		return cd, imagePath, fmt.Errorf("failed to write layout file: %w", err)
-	}
-	return cd, imagePath, nil
+	return nil
 }
 
 func findChartVersion(
@@ -531,4 +374,28 @@ func findChartVersion(
 			name, version)
 	}
 	return chartVersion, nil
+}
+
+func loadChartFromReader(r io.Reader) (*chart.Chart, error) {
+	cd, err := newFileCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tmp dir: %w", err)
+	}
+	defer os.RemoveAll(cd)
+
+	f, err := os.CreateTemp(cd, "tmp-*.tgz")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tmp file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, r); err != nil {
+		return nil, fmt.Errorf("failed to write tmp file %q: %w", f.Name(), err)
+	}
+	tmpFilePath := f.Name() // name is the absolute path of the file
+	chart, err := loader.Load(tmpFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load chart %q: %w", tmpFilePath, err)
+	}
+	return chart, nil
 }

--- a/pkg/hangar/archive/oci/chart.go
+++ b/pkg/hangar/archive/oci/chart.go
@@ -1,0 +1,534 @@
+package oci
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/cnrancher/hangar/pkg/hangar/archive"
+	"github.com/cnrancher/hangar/pkg/image/destination"
+	"github.com/cnrancher/hangar/pkg/image/manifest"
+	"github.com/cnrancher/hangar/pkg/image/source"
+	"github.com/cnrancher/hangar/pkg/image/types"
+	"github.com/cnrancher/hangar/pkg/rancher/chartimages"
+	"github.com/cnrancher/hangar/pkg/utils"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/registry"
+	"helm.sh/helm/v3/pkg/repo"
+
+	signaturev5 "github.com/containers/image/v5/signature"
+	typesv5 "github.com/containers/image/v5/types"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type Chart struct {
+	url     string
+	name    string
+	version string
+
+	insecureSkipVerify bool
+	systemContext      *typesv5.SystemContext
+	policy             *signaturev5.Policy
+
+	cacheDir    string
+	imageDir    string
+	imageSource string
+}
+
+type ChartOptions struct {
+	URL     string
+	Name    string
+	Version string
+
+	InsecureSkipVerify bool
+	SystemContext      *typesv5.SystemContext
+	Policy             *signaturev5.Policy
+}
+
+func NewChart(opts *ChartOptions) *Chart {
+	return &Chart{
+		url:                opts.URL,
+		name:               opts.Name,
+		version:            opts.Version,
+		insecureSkipVerify: opts.InsecureSkipVerify,
+		systemContext:      utils.CopySystemContext(opts.SystemContext),
+		policy:             opts.Policy,
+	}
+}
+
+// Fetch chart from remote URL or local directory and convert it to OCI image.
+// Need to use [Chart.Cleanup] method manually to delete the cache directory.
+func (c *Chart) Fetch(ctx context.Context) error {
+	mode, err := os.Stat(c.url)
+	switch {
+	case err == nil && mode.IsDir():
+		return c.fromDirectory()
+	case registry.IsOCI(c.url):
+		return c.fromOCI(ctx)
+	case strings.HasPrefix(c.url, "http://") || strings.HasPrefix(c.url, "https://"):
+		if strings.HasSuffix(c.url, ".tgz") || strings.HasSuffix(c.url, ".tar.gz") {
+			return c.fromURL(ctx)
+		}
+		return c.fromRepo(ctx)
+	default:
+		return fmt.Errorf("invalid URL format %q", c.url)
+	}
+}
+
+func (c *Chart) CacheDir() string {
+	return c.cacheDir
+}
+
+func (c *Chart) ImageDir() string {
+	return c.imageDir
+}
+
+func (c *Chart) image() (*archive.Image, error) {
+	inspector, err := manifest.NewInspector(context.TODO(), &manifest.InspectorOption{
+		ReferenceName: fmt.Sprintf("oci:%v", c.imageDir),
+		SystemContext: utils.SystemContextWithSharedBlobDir(
+			c.systemContext, filepath.Join(c.cacheDir, archive.SharedBlobDir)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create inspector from dir %q: %w",
+			c.imageDir, err)
+	}
+	defer inspector.Close()
+	// Use background context to inspect local directory
+	b, mime, err := inspector.Raw(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect dir %q: %w",
+			c.imageDir, err)
+	}
+	manifestDigest := digest.SHA256.FromBytes(b)
+	if mime != imgspecv1.MediaTypeImageManifest {
+		return nil, fmt.Errorf("image MIME type should be OCI image manifest v1, got %q", mime)
+	}
+	manifest := &imgspecv1.Manifest{}
+	if err := json.Unmarshal(b, manifest); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
+	}
+	spec := archive.ImageSpec{
+		Arch:        "",
+		OS:          "",
+		OSVersion:   "",
+		OSFeatures:  nil,
+		Variant:     "",
+		MediaType:   mime,
+		Layers:      nil,
+		Config:      manifest.Config.Digest,
+		Digest:      manifestDigest,
+		Annotations: manifest.Annotations,
+	}
+	for _, layer := range manifest.Layers {
+		spec.Layers = append(spec.Layers, layer.Digest)
+	}
+	image := &archive.Image{
+		Source:   c.Source(),
+		Tag:      c.version,
+		ArchList: make([]string, 0),
+		OsList:   make([]string, 0),
+		Images:   []archive.ImageSpec{spec},
+	}
+	return image, nil
+}
+
+func (c *Chart) Source() string {
+	return c.imageSource
+}
+
+// WriteArchive writes chart OCI image into the archive file.
+func (c *Chart) WriteArchive(au *archive.Updater) error {
+	if c.cacheDir == "" {
+		return fmt.Errorf("chart is not fetched to the cache directory")
+	}
+	err := au.Append(c.cacheDir)
+	if err != nil {
+		return fmt.Errorf("write dir %q to archive file: %w",
+			c.cacheDir, err)
+	}
+	index := au.Index()
+	image, err := c.image()
+	if err != nil {
+		return err
+	}
+	index.Append(image)
+	au.SetIndex(index)
+	return au.UpdateIndex()
+}
+
+func (c *Chart) Cleanup() error {
+	if c.cacheDir == "" {
+		return nil
+	}
+	return os.RemoveAll(c.cacheDir)
+}
+
+func (c *Chart) fromOCI(ctx context.Context) error {
+	image, err := url.JoinPath(c.url, c.name)
+	if err != nil {
+		return fmt.Errorf("failed to construct image: %w", err)
+	}
+	image = strings.TrimPrefix(image, fmt.Sprintf("%v://", registry.OCIScheme))
+	if c.version != "" {
+		image = fmt.Sprintf("%v:%v", image, c.version)
+	}
+	logrus.Debugf("OCI helm chart image: %v", image)
+	src, err := source.NewSource(&source.Option{
+		Type:          types.TypeDocker,
+		Registry:      utils.GetRegistryName(image),
+		Project:       utils.GetProjectName(image),
+		Name:          utils.GetImageName(image),
+		Tag:           utils.GetImageTag(image),
+		SystemContext: utils.SystemContextWithTLSVerify(c.systemContext, c.insecureSkipVerify),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create source image: %w", err)
+	}
+	if err := src.Init(ctx); err != nil {
+		return fmt.Errorf("failed to init source image: %w", err)
+	}
+
+	cd, err := newFileCacheDir()
+	if err != nil {
+		return fmt.Errorf("failed to create cache dir: %w", err)
+	}
+	c.cacheDir = cd
+	c.imageDir = filepath.Join(c.cacheDir, src.ManifestDigest().Encoded())
+	c.imageSource = image
+	sd := filepath.Join(cd, archive.SharedBlobDir)
+	dest, err := destination.NewDestination(&destination.Option{
+		Type:      types.TypeOci,
+		Directory: c.cacheDir,
+		Name:      utils.GetImageName(image),
+		Tag:       utils.GetImageTag(image),
+		SystemContext: utils.SystemContextWithSharedBlobDir(
+			c.systemContext, sd),
+	})
+	if err != nil {
+		os.RemoveAll(cd)
+		return fmt.Errorf("failed to create dest image: %w", err)
+	}
+	if err := dest.Init(ctx); err != nil {
+		return fmt.Errorf("failed to init dest image: %w", err)
+	}
+
+	err = src.Copy(ctx, &source.CopyOptions{
+		CopyProvenance:     false,
+		SigstorePrivateKey: "",
+		SigstorePassphrase: nil,
+		Destination:        dest,
+		Set:                make(types.FilterSet),
+		Policy:             c.policy,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to copy image %q to %q: %w",
+			src.ReferenceName(), dest.ReferenceName(), err)
+	}
+	return nil
+}
+
+func (c *Chart) fromRepo(ctx context.Context) error {
+	logrus.Debugf("Get helm chart %q version %q from %q",
+		c.name, c.version, c.url)
+	if c.name == "" {
+		return fmt.Errorf("chart name not provided")
+	}
+	client := &http.Client{
+		Timeout: time.Second * 30,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: c.insecureSkipVerify},
+			Proxy:           http.ProxyFromEnvironment,
+		},
+	}
+	indexURL, err := url.JoinPath(c.url, "index.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to join index URL: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, indexURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create http request: %w", err)
+	}
+	resp, err := utils.HTTPClientDoWithRetry(ctx, client, req)
+	if err != nil {
+		return fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("failed to request index %q: %v", indexURL, resp.Status)
+	}
+	indexData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to fetch index data from %q: %w", c.url, err)
+	}
+	indexCacheDir, err := newFileCacheDir()
+	if err != nil {
+		return fmt.Errorf("failed to init index cache dir: %w", err)
+	}
+	defer os.RemoveAll(indexCacheDir)
+	if err := os.WriteFile(filepath.Join(indexCacheDir, "index.yaml"), indexData, 0600); err != nil {
+		return fmt.Errorf("failed to write index file: %w", err)
+	}
+	index, err := repo.LoadIndexFile(filepath.Join(indexCacheDir, "index.yaml"))
+	if err != nil {
+		return fmt.Errorf("failed to load index: %w", err)
+	}
+	chartVersion, err := findChartVersion(index, c.name, c.version)
+	if err != nil {
+		return fmt.Errorf("failed to get chart %q, version %q: %w",
+			c.name, c.version, err)
+	}
+	chartURL, err := url.JoinPath(c.url, chartVersion.URLs[0])
+	if err != nil {
+		return fmt.Errorf("failed to get chart URL: %w", err)
+	}
+	c.imageSource = chartURL
+	c.cacheDir, c.imageDir, err = fromURL(ctx, chartURL, c.insecureSkipVerify)
+	return err
+}
+
+func (c *Chart) fromDirectory() error {
+	repoIndex, err := chartimages.BuildOrGetIndex(c.url)
+	if err != nil {
+		return fmt.Errorf("failed to get repo index: %w", err)
+	}
+
+	chartVersion, err := findChartVersion(repoIndex, c.name, c.version)
+	if err != nil {
+		return fmt.Errorf("failed to get chart %q, version %q: %w",
+			c.name, c.version, err)
+	}
+
+	chartPath := filepath.Join(c.url, chartVersion.URLs[0])
+	f, err := os.Open(chartPath)
+	if err != nil {
+		return fmt.Errorf("failed to open chart file %q", chartPath)
+	}
+	defer f.Close()
+	c.imageSource = chartPath
+	c.cacheDir, c.imageDir, err = fromReader(f)
+	return err
+}
+
+func (c *Chart) fromURL(ctx context.Context) error {
+	var err error
+	c.imageSource = c.url
+	c.cacheDir, c.imageDir, err = fromURL(ctx, c.url, c.insecureSkipVerify)
+	return err
+}
+
+func fromURL(
+	ctx context.Context, url string, insecureSkipVerify bool,
+) (cache string, image string, err error) {
+	logrus.Debugf("Get helm chart from %q", url)
+	client := &http.Client{
+		Timeout: time.Second * 30,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
+			Proxy:           http.ProxyFromEnvironment,
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create http request: %w", err)
+	}
+	resp, err := utils.HTTPClientDoWithRetry(ctx, client, req)
+	if err != nil {
+		return "", "", fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", "", fmt.Errorf("failed to get url %q: %v", url, resp.Status)
+	}
+	cache, image, err = fromReader(resp.Body)
+	return
+}
+
+func fromReader(r io.Reader) (cache string, image string, err error) {
+	layerData, err := io.ReadAll(r)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to fetch chart data: %w", err)
+	}
+	cd, err := newFileCacheDir()
+	if err != nil {
+		return "", "", err
+	}
+
+	layerDigest := digest.SHA256.FromBytes(layerData)
+	tmpChartName := fmt.Sprintf("sha256-%x.tgz", layerDigest.Encoded())
+	tmpChartPath := filepath.Join(cd, tmpChartName)
+	f, err := os.Create(tmpChartPath)
+	if err != nil {
+		return cd, "", fmt.Errorf("failed to create %q: %w", tmpChartPath, err)
+	}
+	defer f.Close()
+	_, err = f.Write(layerData)
+	if err != nil {
+		return cd, "", fmt.Errorf("failed to write %q: %w", tmpChartPath, err)
+	}
+
+	c, err := loader.Load(tmpChartPath)
+	if err != nil {
+		return cd, "", fmt.Errorf("failed to load chart: %w", err)
+	}
+	configData, err := json.MarshalIndent(c.Metadata, "", "  ")
+	if err != nil {
+		return cd, "", fmt.Errorf("failed to marshal chart metadata: %w", err)
+	}
+	configDigest := digest.SHA256.FromBytes(configData)
+
+	m := &imgspecv1.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: imgspecv1.MediaTypeImageManifest,
+		Config: imgspecv1.Descriptor{
+			MediaType: registry.ConfigMediaType,
+			Size:      int64(len(configData)),
+			Digest:    configDigest,
+		},
+		Layers: []imgspecv1.Descriptor{
+			{
+				MediaType: registry.ChartLayerMediaType,
+				Size:      int64(len(layerData)),
+				Digest:    layerDigest,
+			},
+		},
+		Annotations: map[string]string{
+			imgspecv1.AnnotationURL:         c.Metadata.Home,
+			imgspecv1.AnnotationVersion:     c.Metadata.Version,
+			imgspecv1.AnnotationTitle:       c.Metadata.Name,
+			imgspecv1.AnnotationDescription: c.Metadata.Description,
+		},
+	}
+	manifestData, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return cd, "", fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+	manifestDigest := digest.SHA256.FromBytes(manifestData)
+
+	// Construct chart file to containers OCI format
+	err = os.Mkdir(filepath.Join(cd, manifestDigest.Encoded()), 0755)
+	if err != nil {
+		return cd, "", fmt.Errorf("mkdir failed on %q: %w",
+			filepath.Join(cd, manifestDigest.Encoded()), err)
+	}
+	// Create share blobs path
+	sharedBlobPath := filepath.Join(cd, archive.SharedBlobDir, "sha256")
+	if err = os.MkdirAll(sharedBlobPath, 0755); err != nil {
+		return cd, "", fmt.Errorf("mkdir failed %q: %w", sharedBlobPath, err)
+	}
+	// Chart layer
+	if err = os.Rename(tmpChartPath,
+		filepath.Join(sharedBlobPath, layerDigest.Encoded())); err != nil {
+		return cd, "", fmt.Errorf("chart layer file rename failed: %w", err)
+	}
+	// Manifest file
+	if err = os.WriteFile(filepath.Join(sharedBlobPath, manifestDigest.Encoded()), manifestData, 0644); err != nil {
+		return cd, "", fmt.Errorf("failed to write manifest: %w", err)
+	}
+	// Config file
+	if err = os.WriteFile(filepath.Join(sharedBlobPath, configDigest.Encoded()), configData, 0644); err != nil {
+		return cd, "", fmt.Errorf("failed to write config: %w", err)
+	}
+	// OCI Image index
+	imagePath := filepath.Join(cd, manifestDigest.Encoded())
+	if err = os.MkdirAll(filepath.Join(imagePath, imgspecv1.ImageBlobsDir), 0755); err != nil {
+		return cd, "", fmt.Errorf("mkdir failed %q: %w", imagePath, err)
+	}
+	index := imgspecv1.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		Manifests: []imgspecv1.Descriptor{
+			{
+				MediaType: imgspecv1.MediaTypeImageManifest,
+				Digest:    manifestDigest,
+				Size:      int64(len(manifestData)),
+			},
+		},
+	}
+	indexData, err := json.Marshal(index)
+	if err != nil {
+		return cd, imagePath, fmt.Errorf("failed to marshal manifest index: %w", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(imagePath, imgspecv1.ImageIndexFile), indexData, 0644); err != nil {
+		return cd, imagePath, fmt.Errorf("failed to write manifest index: %w", err)
+	}
+	// Image Layout
+	layout := imgspecv1.ImageLayout{
+		Version: imgspecv1.ImageLayoutVersion,
+	}
+	layoutData, err := json.Marshal(layout)
+	if err != nil {
+		return cd, imagePath, fmt.Errorf("failed to marshal image layout: %w", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(imagePath, imgspecv1.ImageLayoutFile), layoutData, 0644); err != nil {
+		return cd, imagePath, fmt.Errorf("failed to write layout file: %w", err)
+	}
+	return cd, imagePath, nil
+}
+
+func findChartVersion(
+	index *repo.IndexFile, name string, version string,
+) (*repo.ChartVersion, error) {
+	if name == "" {
+		return nil, fmt.Errorf("chart name not provided")
+	}
+	var versions repo.ChartVersions
+	for n, v := range index.Entries {
+		if n == name {
+			versions = v
+			break
+		}
+	}
+	if versions == nil {
+		return nil, fmt.Errorf("chart %q not found in repository", name)
+	}
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("chart %q does not have any versions in repo", name)
+	}
+	var chartVersion *repo.ChartVersion
+	if version != "" {
+		expectedVersion, err := semver.NewVersion(version)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse version %q: %w", version, err)
+		}
+		for _, v := range versions {
+			v1, err := semver.NewVersion(v.Version)
+			if err != nil {
+				continue
+			}
+			if v1.Equal(expectedVersion) {
+				chartVersion = v
+				break
+			}
+		}
+		if chartVersion == nil {
+			return nil, fmt.Errorf("failed to find chart %q version %q", name, version)
+		}
+	} else {
+		chartVersion = versions[0]
+	}
+
+	if len(chartVersion.URLs) == 0 {
+		return nil, fmt.Errorf("chart %q version %q does not have URLs provided",
+			name, version)
+	}
+	return chartVersion, nil
+}

--- a/pkg/hangar/archive/oci/chart_test.go
+++ b/pkg/hangar/archive/oci/chart_test.go
@@ -20,39 +20,47 @@ var policy = &signature.Policy{
 var opts = []*ChartOptions{
 	// Repository URL
 	{
-		URL:                "https://charts.rancher.cn/2.10-prime/latest/",
-		Name:               "rancher",
-		Version:            "2.10.3-ent",
-		InsecureSkipVerify: false,
-		SystemContext:      utils.CopySystemContext(nil),
-		Policy:             policy,
+		CommonOpts: CommonOpts{
+			InsecureSkipVerify: false,
+			SystemContext:      utils.CopySystemContext(nil),
+			Policy:             policy,
+		},
+		URL:     "https://charts.rancher.cn/2.10-prime/latest/",
+		Name:    "rancher",
+		Version: "2.10.3-ent",
 	},
 	// Tarball URL
 	{
-		URL:                "https://charts.rancher.cn/2.10-prime/latest/rancher-2.10.1-ent.tgz",
-		Name:               "",
-		Version:            "",
-		InsecureSkipVerify: false,
-		SystemContext:      utils.CopySystemContext(nil),
-		Policy:             policy,
+		CommonOpts: CommonOpts{
+			InsecureSkipVerify: false,
+			SystemContext:      utils.CopySystemContext(nil),
+			Policy:             policy,
+		},
+		URL:     "https://charts.rancher.cn/2.10-prime/latest/rancher-2.10.1-ent.tgz",
+		Name:    "",
+		Version: "",
 	},
 	// OCI repository
 	{
-		URL:                "oci://ghcr.io/nginx/charts",
-		Name:               "nginx-ingress",
-		Version:            "2.0.1",
-		InsecureSkipVerify: false,
-		SystemContext:      utils.CopySystemContext(nil),
-		Policy:             policy,
+		CommonOpts: CommonOpts{
+			InsecureSkipVerify: false,
+			SystemContext:      utils.CopySystemContext(nil),
+			Policy:             policy,
+		},
+		URL:     "oci://ghcr.io/nginx/charts",
+		Name:    "nginx-ingress",
+		Version: "2.0.1",
 	},
 	// Directory (skip if not exists)
 	{
-		URL:                "./test/charts",
-		Name:               "rancher-eks-operator",
-		Version:            "",
-		InsecureSkipVerify: false,
-		SystemContext:      utils.CopySystemContext(nil),
-		Policy:             policy,
+		CommonOpts: CommonOpts{
+			InsecureSkipVerify: false,
+			SystemContext:      utils.CopySystemContext(nil),
+			Policy:             policy,
+		},
+		URL:     "./test/charts",
+		Name:    "rancher-eks-operator",
+		Version: "",
 	},
 }
 

--- a/pkg/hangar/archive/oci/chart_test.go
+++ b/pkg/hangar/archive/oci/chart_test.go
@@ -1,0 +1,83 @@
+package oci
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cnrancher/hangar/pkg/utils"
+	"github.com/containers/image/v5/signature"
+)
+
+var policy = &signature.Policy{
+	Default: []signature.PolicyRequirement{
+		signature.NewPRInsecureAcceptAnything(),
+	},
+	Transports: make(map[string]signature.PolicyTransportScopes),
+}
+
+var opts = []*ChartOptions{
+	// Repository URL
+	{
+		URL:                "https://charts.rancher.cn/2.10-prime/latest/",
+		Name:               "rancher",
+		Version:            "2.10.3-ent",
+		InsecureSkipVerify: false,
+		SystemContext:      utils.CopySystemContext(nil),
+		Policy:             policy,
+	},
+	// Tarball URL
+	{
+		URL:                "https://charts.rancher.cn/2.10-prime/latest/rancher-2.10.1-ent.tgz",
+		Name:               "",
+		Version:            "",
+		InsecureSkipVerify: false,
+		SystemContext:      utils.CopySystemContext(nil),
+		Policy:             policy,
+	},
+	// OCI repository
+	{
+		URL:                "oci://ghcr.io/nginx/charts",
+		Name:               "nginx-ingress",
+		Version:            "2.0.1",
+		InsecureSkipVerify: false,
+		SystemContext:      utils.CopySystemContext(nil),
+		Policy:             policy,
+	},
+	// Directory (skip if not exists)
+	{
+		URL:                "./test/charts",
+		Name:               "rancher-eks-operator",
+		Version:            "",
+		InsecureSkipVerify: false,
+		SystemContext:      utils.CopySystemContext(nil),
+		Policy:             policy,
+	},
+}
+
+func Test_Chart(t *testing.T) {
+	for _, o := range opts {
+		if strings.HasPrefix(o.URL, "./") {
+			if _, err := os.Stat(o.URL); err != nil {
+				t.Logf("skip test %q", o.URL)
+				continue
+			}
+		}
+		c := NewChart(o)
+		defer c.Cleanup()
+		if err := c.Fetch(context.TODO()); err != nil {
+			t.Errorf("faied to fetch %q: %v", c.url, err)
+			return
+		}
+		t.Logf("chart %q cache dir: %q\n", c.url, c.cacheDir)
+
+		img, err := c.image()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		t.Logf("%q:\n%v\n", c.cacheDir, utils.ToJSON(img))
+		t.Logf("------------------------------\n")
+	}
+}

--- a/pkg/hangar/archive/oci/common.go
+++ b/pkg/hangar/archive/oci/common.go
@@ -1,11 +1,252 @@
 package oci
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"maps"
 	"os"
+	"path/filepath"
+	"slices"
 
+	"github.com/cnrancher/hangar/pkg/hangar/archive"
 	"github.com/cnrancher/hangar/pkg/utils"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"helm.sh/helm/v3/pkg/registry"
+
+	signaturev5 "github.com/containers/image/v5/signature"
+	typesv5 "github.com/containers/image/v5/types"
 )
+
+type common struct {
+	insecureSkipVerify bool
+	systemContext      *typesv5.SystemContext
+	policy             *signaturev5.Policy
+
+	cacheDir    string
+	imageDir    string
+	imageSource string
+
+	manifestDigest digest.Digest
+	config         any
+	configDigest   digest.Digest
+	layerMediaType string
+	annotations    map[string]string
+	layers         []digest.Digest
+	imageTag       string
+}
+
+type CommonOpts struct {
+	InsecureSkipVerify bool
+	SystemContext      *typesv5.SystemContext
+	Policy             *signaturev5.Policy
+}
+
+func (c *common) CacheDir() string {
+	return c.cacheDir
+}
+
+func (c *common) ImageDir() string {
+	return c.imageDir
+}
+
+func (c *common) Source() string {
+	return c.imageSource
+}
+
+func (c *common) Cleanup() error {
+	if c.cacheDir == "" {
+		return nil
+	}
+	return os.RemoveAll(c.cacheDir)
+}
+
+func (c *common) constructOCIImage(r io.Reader) error {
+	if len(c.annotations) == 0 {
+		return fmt.Errorf("annotations not set")
+	}
+	if c.config == nil {
+		return fmt.Errorf("config not initialized")
+	}
+	if c.layerMediaType == "" {
+		return fmt.Errorf("layer mediaType not set")
+	}
+
+	cd, err := newFileCacheDir()
+	c.cacheDir = cd
+	if err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp(cd, "tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpFilePath := tmpFile.Name()
+	defer tmpFile.Close()
+	_, err = io.Copy(tmpFile, r)
+	if err != nil {
+		return fmt.Errorf("failed to write layer %q: %w", tmpFilePath, err)
+	}
+
+	tmpFile.Sync()
+	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek file %q to zero: %w", tmpFilePath, err)
+	}
+	layerDigest, err := digest.SHA256.FromReader(tmpFile)
+	if err != nil {
+		return fmt.Errorf("failed to calc %q sha256sum: %w", tmpFilePath, err)
+	}
+
+	configData, err := json.MarshalIndent(c.config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal file config: %w", err)
+	}
+	c.configDigest = digest.SHA256.FromBytes(configData)
+	layerSize, err := tmpFile.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return fmt.Errorf("failed to seek file %q current size: %w", tmpFilePath, err)
+	}
+
+	m := &imgspecv1.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: imgspecv1.MediaTypeImageManifest,
+		Config: imgspecv1.Descriptor{
+			MediaType: registry.ConfigMediaType,
+			Size:      int64(len(configData)),
+			Digest:    c.configDigest,
+		},
+		Layers: []imgspecv1.Descriptor{
+			{
+				MediaType: c.layerMediaType,
+				Size:      layerSize,
+				Digest:    layerDigest,
+			},
+		},
+		Annotations: maps.Clone(c.annotations),
+	}
+	manifestData, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+	c.manifestDigest = digest.SHA256.FromBytes(manifestData)
+	c.layers = append(c.layers, layerDigest)
+
+	// Construct file to containers OCI format
+	err = os.Mkdir(filepath.Join(cd, c.manifestDigest.Encoded()), 0755)
+	if err != nil {
+		return fmt.Errorf("mkdir failed on %q: %w",
+			filepath.Join(cd, c.manifestDigest.Encoded()), err)
+	}
+	// Create share blobs path
+	sharedBlobPath := filepath.Join(cd, archive.SharedBlobDir, "sha256")
+	if err = os.MkdirAll(sharedBlobPath, 0755); err != nil {
+		return fmt.Errorf("mkdir failed %q: %w", sharedBlobPath, err)
+	}
+	// File layer
+	if err = os.Rename(tmpFilePath,
+		filepath.Join(sharedBlobPath, layerDigest.Encoded())); err != nil {
+		return fmt.Errorf("layer file rename failed: %w", err)
+	}
+	// Manifest file
+	if err = os.WriteFile(filepath.Join(sharedBlobPath, c.manifestDigest.Encoded()), manifestData, 0644); err != nil {
+		return fmt.Errorf("failed to write manifest: %w", err)
+	}
+	// Config file
+	if err = os.WriteFile(filepath.Join(sharedBlobPath, c.configDigest.Encoded()), configData, 0644); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+	// OCI Image index
+	imagePath := filepath.Join(cd, c.manifestDigest.Encoded())
+	if err = os.MkdirAll(filepath.Join(imagePath, imgspecv1.ImageBlobsDir), 0755); err != nil {
+		return fmt.Errorf("mkdir failed %q: %w", imagePath, err)
+	}
+	c.imageDir = imagePath
+	index := imgspecv1.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		Manifests: []imgspecv1.Descriptor{
+			{
+				MediaType: imgspecv1.MediaTypeImageManifest,
+				Digest:    c.manifestDigest,
+				Size:      int64(len(manifestData)),
+			},
+		},
+	}
+	indexData, err := json.Marshal(index)
+	if err != nil {
+		return fmt.Errorf("failed to marshal manifest index: %w", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(imagePath, imgspecv1.ImageIndexFile), indexData, 0644); err != nil {
+		return fmt.Errorf("failed to write manifest index: %w", err)
+	}
+	// Image Layout
+	layout := imgspecv1.ImageLayout{
+		Version: imgspecv1.ImageLayoutVersion,
+	}
+	layoutData, err := json.Marshal(layout)
+	if err != nil {
+		return fmt.Errorf("failed to marshal image layout: %w", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(imagePath, imgspecv1.ImageLayoutFile), layoutData, 0644); err != nil {
+		return fmt.Errorf("failed to write layout file: %w", err)
+	}
+	return nil
+}
+
+func (c *common) image() (*archive.Image, error) {
+	spec := archive.ImageSpec{
+		Arch:        "",
+		OS:          "",
+		OSVersion:   "",
+		OSFeatures:  nil,
+		Variant:     "",
+		MediaType:   imgspecv1.MediaTypeImageManifest,
+		Layers:      nil,
+		Config:      c.configDigest,
+		Digest:      c.manifestDigest,
+		Annotations: c.annotations,
+	}
+	spec.Layers = slices.Clone(c.layers)
+	image := &archive.Image{
+		Source:   c.Source(),
+		Tag:      c.imageTag,
+		ArchList: make([]string, 0),
+		OsList:   make([]string, 0),
+		Images:   []archive.ImageSpec{spec},
+	}
+	if image.Tag == "" {
+		image.Tag = utils.DefaultTag
+	}
+	return image, nil
+}
+
+// WriteArchive writes chart OCI image into the archive file.
+func (c *common) WriteArchive(au *archive.Updater) error {
+	if c.cacheDir == "" {
+		return fmt.Errorf("chart is not fetched to the cache directory")
+	}
+	err := au.Append(c.cacheDir)
+	if err != nil {
+		return fmt.Errorf("write dir %q to archive file: %w",
+			c.cacheDir, err)
+	}
+	index := au.Index()
+	image, err := c.image()
+	if err != nil {
+		return err
+	}
+	index.Append(image)
+	au.SetIndex(index)
+	return au.UpdateIndex()
+}
 
 func newFileCacheDir() (string, error) {
 	cd, err := os.MkdirTemp(utils.HangarCacheDir(), "*")

--- a/pkg/hangar/archive/oci/common.go
+++ b/pkg/hangar/archive/oci/common.go
@@ -1,0 +1,16 @@
+package oci
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cnrancher/hangar/pkg/utils"
+)
+
+func newFileCacheDir() (string, error) {
+	cd, err := os.MkdirTemp(utils.HangarCacheDir(), "*")
+	if err != nil {
+		return "", fmt.Errorf("os.MkdirTemp: %w", err)
+	}
+	return cd, nil
+}

--- a/pkg/hangar/archive/oci/file.go
+++ b/pkg/hangar/archive/oci/file.go
@@ -1,0 +1,129 @@
+package oci
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cnrancher/hangar/pkg/utils"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"helm.sh/helm/v3/pkg/registry"
+)
+
+const (
+	DefaultFileProject = "hangar-file"
+
+	FileLayerMediaType = "application/vnd.content.hangar.file.layer.v1"
+)
+
+type File struct {
+	common
+
+	url string
+}
+
+type FileOptions struct {
+	CommonOpts
+
+	URL string
+}
+
+type FileConfig struct {
+	Name string
+}
+
+func NewFile(opts *FileOptions) *File {
+	return &File{
+		common: common{
+			insecureSkipVerify: opts.CommonOpts.InsecureSkipVerify,
+			systemContext:      utils.CopySystemContext(opts.CommonOpts.SystemContext),
+			policy:             opts.CommonOpts.Policy,
+		},
+		url: opts.URL,
+	}
+}
+
+// Fetch file from remote URL or local directory and convert it to OCI image.
+// Need to use [common.Cleanup] method manually to delete the cache directory.
+func (f *File) Fetch(ctx context.Context) error {
+	name := filepath.Base(f.url)
+	f.imageSource = fmt.Sprintf("%v/%v/%v",
+		utils.DockerHubRegistry, DefaultFileProject, name)
+	f.imageTag = utils.DefaultTag
+
+	mode, err := os.Stat(f.url)
+	switch {
+	case err == nil:
+		if mode.IsDir() {
+			return fmt.Errorf("%v is a directory", f.url)
+		}
+		return f.fromDirectory()
+	case registry.IsOCI(f.url):
+		return fmt.Errorf("file protocol does not support Helm OCI image")
+	case strings.HasPrefix(f.url, "http://") || strings.HasPrefix(f.url, "https://"):
+		return f.fromURL(ctx)
+	default:
+		return fmt.Errorf("invalid URL %q: %w", f.url, err)
+	}
+}
+
+func (f *File) fromDirectory() error {
+	file, err := os.Open(f.url)
+	if err != nil {
+		return fmt.Errorf("failed to open file %q", f.url)
+	}
+	defer file.Close()
+	return f.fromReader(file)
+}
+
+func (f *File) fromURL(ctx context.Context) error {
+	client := &http.Client{
+		Timeout: time.Second * 30,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: f.insecureSkipVerify},
+			Proxy:           http.ProxyFromEnvironment,
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create http request: %w", err)
+	}
+	resp, err := utils.HTTPClientDoWithRetry(ctx, client, req)
+	if err != nil {
+		return fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("failed to get url %q: %v", f.url, resp.Status)
+	}
+	return f.fromReader(resp.Body)
+}
+
+// fromReader constructs the Hangar OCI format File image into
+// the cache directory from [io.Reader].
+func (f *File) fromReader(r io.Reader) (err error) {
+	fileName := filepath.Base(f.url)
+	f.annotations = map[string]string{
+		imgspecv1.AnnotationTitle:       fileName,
+		imgspecv1.AnnotationDescription: f.url,
+		imgspecv1.AnnotationVendor:      "Hangar",
+		imgspecv1.AnnotationCreated:     time.Now().Format(time.RFC3339),
+	}
+	f.config = &FileConfig{
+		Name: fileName,
+	}
+	f.layerMediaType = FileLayerMediaType
+
+	if err := f.constructOCIImage(r); err != nil {
+		return fmt.Errorf("failed to construct OCI image from file %q: %w",
+			f.url, err)
+	}
+	return nil
+}

--- a/pkg/hangar/archive/oci/file_test.go
+++ b/pkg/hangar/archive/oci/file_test.go
@@ -1,0 +1,57 @@
+package oci
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cnrancher/hangar/pkg/utils"
+)
+
+var file_opts = []*FileOptions{
+	// Remote URL
+	{
+		CommonOpts: CommonOpts{
+			InsecureSkipVerify: false,
+			SystemContext:      utils.CopySystemContext(nil),
+			Policy:             policy,
+		},
+		URL: "https://charts.rancher.cn/2.10-prime/latest/rancher-2.10.1-ent.tgz",
+	},
+	// Local File (skip if not exists)
+	{
+		CommonOpts: CommonOpts{
+			InsecureSkipVerify: false,
+			SystemContext:      utils.CopySystemContext(nil),
+			Policy:             policy,
+		},
+		URL: "./test/.gitignore",
+	},
+}
+
+func Test_File(t *testing.T) {
+	for _, o := range file_opts {
+		if strings.HasPrefix(o.URL, "./") {
+			if _, err := os.Stat(o.URL); err != nil {
+				t.Logf("skip test %q", o.URL)
+				continue
+			}
+		}
+		f := NewFile(o)
+		defer f.Cleanup()
+		if err := f.Fetch(context.TODO()); err != nil {
+			t.Errorf("faied to fetch %q: %v", f.url, err)
+			return
+		}
+		t.Logf("file %q cache dir: %q\n", f.url, f.cacheDir)
+
+		img, err := f.image()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		t.Logf("%q:\n%v\n", f.cacheDir, utils.ToJSON(img))
+		t.Logf("------------------------------\n")
+	}
+}

--- a/pkg/hangar/archive/reader.go
+++ b/pkg/hangar/archive/reader.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -210,4 +211,8 @@ func (r *Reader) FileCompressedSize(name string) (int, error) {
 		}
 	}
 	return 0, os.ErrNotExist
+}
+
+func (r *Reader) LoadFile(name string) (fs.File, error) {
+	return r.zr.Open(name)
 }

--- a/pkg/hangar/loader.go
+++ b/pkg/hangar/loader.go
@@ -338,6 +338,7 @@ func (l *Loader) worker(ctx context.Context, o any) {
 		}
 		allowedDigests[img.Digest.String()] = true
 	}
+	var skipManifestIndex bool
 	var copiedManifestImages = make(manifest.Images, 0)
 	for _, img := range obj.image.Images {
 		if img.Digest == "" {
@@ -438,6 +439,10 @@ func (l *Loader) worker(ctx context.Context, o any) {
 			return
 		}
 
+		if src.IsHelmChart() {
+			skipManifestIndex = true
+		}
+
 		var mi *manifest.Image
 		mi, err = manifest.NewImageByInspect(
 			copyContext, dest.ReferenceNameDigest(img.Digest), dest.SystemContext(),
@@ -450,6 +455,9 @@ func (l *Loader) worker(ctx context.Context, o any) {
 			img.Arch, img.Variant, img.OS, img.OSVersion, img.OSFeatures)
 		mi.Annotations = img.Annotations
 		copiedManifestImages = append(copiedManifestImages, mi)
+	}
+	if skipManifestIndex {
+		return
 	}
 
 	destManifestImages := dest.ManifestImages()

--- a/pkg/hangar/mirrorer.go
+++ b/pkg/hangar/mirrorer.go
@@ -283,6 +283,11 @@ func (m *Mirrorer) worker(ctx context.Context, o any) {
 		return
 	}
 
+	if obj.source.IsHelmChart() {
+		// Do not create manifest index for OCI helm chart.
+		return
+	}
+
 	copiedImage := obj.source.GetCopiedImage()
 	if len(copiedImage.Images) == 0 {
 		return

--- a/pkg/image/destination/destination.go
+++ b/pkg/image/destination/destination.go
@@ -200,6 +200,12 @@ func (d *Destination) ReferenceAttName(
 	}
 }
 
+func (d *Destination) ReferenceHelmChart(
+	sha256sum string,
+) (typesv5.ImageReference, error) {
+	return d.ReferenceMultiArch("", "", "", "", sha256sum)
+}
+
 func (d *Destination) ReferenceAtt(
 	sha256sum string,
 ) (typesv5.ImageReference, error) {

--- a/pkg/image/destination/destination.go
+++ b/pkg/image/destination/destination.go
@@ -200,10 +200,23 @@ func (d *Destination) ReferenceAttName(
 	}
 }
 
+func (d *Destination) ReferenceNameHelmChart(
+	sha256sum string,
+) string {
+	switch d.imageType {
+	case types.TypeDir,
+		types.TypeOci:
+		return filepath.Join(d.referenceName, sha256sum)
+	default:
+		// Helm chart/Custom File does not need multi-platform manifest list
+		return d.referenceName
+	}
+}
+
 func (d *Destination) ReferenceHelmChart(
 	sha256sum string,
 ) (typesv5.ImageReference, error) {
-	return d.ReferenceMultiArch("", "", "", "", sha256sum)
+	return alltransportsv5.ParseImageName(d.ReferenceNameHelmChart(sha256sum))
 }
 
 func (d *Destination) ReferenceAtt(

--- a/pkg/image/internal/private/private.go
+++ b/pkg/image/internal/private/private.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/common/pkg/retry"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"helm.sh/helm/v3/pkg/registry"
 )
 
 const (
@@ -60,4 +61,8 @@ func IsAttestations(m *imgspecv1.Descriptor) bool {
 		return false
 	}
 	return true
+}
+
+func IsHelmChart(m *imgspecv1.Manifest) bool {
+	return m.Config.MediaType == registry.ConfigMediaType
 }

--- a/pkg/image/source/source.go
+++ b/pkg/image/source/source.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cnrancher/hangar/pkg/image/manifest"
 	"github.com/cnrancher/hangar/pkg/image/types"
 	"github.com/cnrancher/hangar/pkg/utils"
+	"helm.sh/helm/v3/pkg/registry"
 
 	manifestv5 "github.com/containers/image/v5/manifest"
 	alltransportsv5 "github.com/containers/image/v5/transports/alltransports"
@@ -599,4 +600,18 @@ func (s *Source) IsSigstoreSignature() bool {
 		}
 	}
 	return false
+}
+
+func (s *Source) IsHelmChart() bool {
+	if s.mime != imgspecv1.MediaTypeImageManifest {
+		return false
+	}
+	if s.ociManifest.Config.MediaType != registry.ConfigMediaType {
+		return false
+	}
+	return true
+}
+
+func (s *Source) ManifestDigest() digest.Digest {
+	return s.manifestDigest
 }

--- a/pkg/image/types/types.go
+++ b/pkg/image/types/types.go
@@ -91,20 +91,20 @@ func (s FilterSet) AllowArch(arch string) bool {
 	if len(s["arch"]) == 0 {
 		return true
 	}
-	if len(arch) > 0 {
-		return s["arch"][arch]
+	if len(arch) == 0 {
+		return true
 	}
-	return false
+	return s["arch"][arch]
 }
 
 func (s FilterSet) AllowOS(os string) bool {
 	if len(s["os"]) == 0 {
 		return true
 	}
-	if len(os) > 0 {
-		return s["os"][os]
+	if len(os) == 0 {
+		return true
 	}
-	return false
+	return s["os"][os]
 }
 
 func (s FilterSet) AllowVariant(v string) bool {
@@ -114,8 +114,5 @@ func (s FilterSet) AllowVariant(v string) bool {
 	if len(v) == 0 {
 		return true
 	}
-	if len(v) > 0 {
-		return s["variant"][v]
-	}
-	return false
+	return s["variant"][v]
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -266,9 +266,8 @@ func GetProjectName(image string) string {
 	case 2:
 		if strings.ContainsAny(s[0], ".:") || s[0] == LocalHost {
 			return DefaultProject
-		} else {
-			return s[0]
 		}
+		return s[0]
 	case 3:
 		return s[1]
 	default:
@@ -305,9 +304,8 @@ func GetRegistryName(image string) string {
 	case 2:
 		if strings.ContainsAny(s[0], ".:") || s[0] == LocalHost {
 			return s[0]
-		} else {
-			return DockerHubRegistry
 		}
+		return DockerHubRegistry
 	case 3:
 		return s[0]
 	default:

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -1,6 +1,7 @@
 package utils
 
 var (
+	Name      = "hangar"
 	Version   = "v1.9.1"
 	GitCommit = "HEAD"
 )

--- a/test/scripts/run.sh
+++ b/test/scripts/run.sh
@@ -50,7 +50,7 @@ done
 tox -e flake8
 
 if [[ ${HARBOR:-} = "" ]] && [[ ${DISTRIBUTION:-} = "" ]]; then
-    HARBOR=1
+    # HARBOR=1
     DISTRIBUTION=1
 fi
 

--- a/test/suite/data/archive/store_ls.log
+++ b/test/suite/data/archive/store_ls.log
@@ -1,0 +1,7 @@
+- [INFO] Index version: v1.2.0
+- [INFO] Images:
+   1 | docker.io/hangar-helm/rancher:2.10.3-ent | NOARCH | NOOS | 16.50K | (helm chart)
+   2 | docker.io/hangar-helm/rancher:2.10.1-ent | NOARCH | NOOS | 16.47K | (helm chart)
+   3 | ghcr.io/nginx/charts/nginx-ingress:2.0.1 | NOARCH | NOOS | 41.67K | (helm chart)
+   4 | docker.io/hangar-file/save.txt:latest | NOARCH | NOOS | 0.16K | (custom file)
+   5 | docker.io/hangar-file/v2.10.3-ent_sha256sum.txt:latest | NOARCH | NOOS | 0.45K | (custom file)

--- a/test/suite/test_archive.py
+++ b/test/suite/test_archive.py
@@ -8,9 +8,11 @@ Automatin tests for following commands:
     "hangar sync validate"
     "hangar load"
     "hangar load validate"
-    "hangar archive ls"
     "hangar archive merge"
     "hangar archive export"
+    "hangar archive store chart"
+    "hangar arcihve store file
+    "hangar archive ls"
 """
 
 import pytest

--- a/test/suite/test_archive_store.py
+++ b/test/suite/test_archive_store.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+"""
+Automatin tests for following commands:
+    "hangar archive init"
+    "hangar archive store chart"
+    "hangar arcihve store file
+    "hangar archive ls"
+"""
+
+from .common import run_hangar, check, compare, prepare
+from .common import REGISTRY_URL, REGISTRY_PASSWORD
+
+ARCHIVE_NAME = "test_store_archive.zip"
+
+
+def test_login():
+    check(run_hangar([
+        "login",
+        REGISTRY_URL,
+        "-u=admin",
+        "-p", REGISTRY_PASSWORD,
+        "--tls-verify=false",
+    ]))
+
+
+def test_archive_init():
+    prepare(ARCHIVE_NAME)
+    run_hangar([
+        "archive",
+        "init",
+        ARCHIVE_NAME,
+    ])
+
+
+def test_store_chart():
+    # Store chart from Helm HTTP Repo
+    run_hangar([
+        "archive",
+        "store",
+        "chart",
+        "-f", ARCHIVE_NAME,
+        "https://charts.rancher.cn/2.10-prime/latest/",
+        "--name=rancher",
+        "--version=2.10.3-ent",
+    ])
+
+    # Store chart from Tarball URL
+    run_hangar([
+        "archive",
+        "store",
+        "chart",
+        "-f", ARCHIVE_NAME,
+        "https://charts.rancher.cn/2.10-prime/latest/rancher-2.10.1-ent.tgz",
+    ])
+
+    # Store chart from OCI Repository
+    run_hangar([
+        "archive",
+        "store",
+        "chart",
+        "-f", ARCHIVE_NAME,
+        "oci://ghcr.io/nginx/charts",
+        "--name=nginx-ingress",
+        "--version=2.0.1",
+    ])
+
+    # Store file from local directory
+    run_hangar([
+        "archive",
+        "store",
+        "file",
+        "-f", ARCHIVE_NAME,
+        "./data/archive/save.txt",
+    ])
+
+    # Store file from remote URL
+    run_hangar([
+        "archive",
+        "store",
+        "file",
+        "-f", ARCHIVE_NAME,
+        "https://dl.rancher.cn/2.10/v2.10.3-ent_sha256sum.txt",
+    ])
+
+
+def test_archive_ls():
+    log = run_hangar([
+        "archive",
+        "ls",
+        "-f", ARCHIVE_NAME,
+        "--hide-log-time",
+    ])
+    compare(log, "data/archive/store_ls.log")

--- a/test/suite/test_archive_store.py
+++ b/test/suite/test_archive_store.py
@@ -5,6 +5,7 @@ Automatin tests for following commands:
     "hangar archive init"
     "hangar archive store chart"
     "hangar arcihve store file
+    "hangar archive export file"
     "hangar archive ls"
 """
 
@@ -81,6 +82,24 @@ def test_store_chart():
         "file",
         "-f", ARCHIVE_NAME,
         "https://dl.rancher.cn/2.10/v2.10.3-ent_sha256sum.txt",
+    ])
+
+    # Extract custom file
+    run_hangar([
+        "archive",
+        "export",
+        "file",
+        "-f", ARCHIVE_NAME,
+        "-n", "v2.10.3-ent_sha256sum.txt",
+        "-y",
+    ])
+    run_hangar([
+        "archive",
+        "export",
+        "file",
+        "-f", ARCHIVE_NAME,
+        "-n", "save.txt",
+        "-y",
     ])
 
 


### PR DESCRIPTION
## Issue
https://github.com/cnrancher/hangar/issues/143

## Describe

```sh
# Init an empty archive file
hangar archive init "<FILENAME>.zip"

# For storing helm charts
hangar archive add chart "https://<CHART_URL>.tgz" -f "<FILENAME>.zip"
hangar archive add chart "oci://repo/chart/name" --version "v0.1.0" -f "<FILENAME>.zip"
hangar archive add chart "./path/to/chart.tgz" -f <FILENAME>.zip
hangar archive add chart "https://<HELM_CHART_REPO_URL>/" --name "CHART_NAME" --version "v1.2.3" -f "<FILENAME>.zip"

# For storing custom files
hangar archive add file "https://<FILE_URL>" -f "<FILENAME>.zip"
hangar archive add file "./path/to/file.txt" -f "<FILENAME>.zip"
# For extracting the custom file from archive
hangar archive export file --name "<FILENAME>" -f "<ARCHIVE_FILE>.zip"
```
